### PR TITLE
Added -http-cache-ttl flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,21 +206,22 @@ Usage:
   imaginary -v | -version
 
 Options:
-  -a <addr>            bind address [default: *]
-  -p <port>            bind port [default: 8088]
-  -h, -help            output help
-  -v, -version         output version
-  -cors                Enable CORS support [default: false]
-  -gzip                Enable gzip compression [default: false]
-  -key <key>           Define API key for authorization
-  -mount <path>        Mount server directory
-  -certfile <path>     TLS certificate file path
-  -keyfile <path>      TLS key file path
-  -concurreny <num>    Throttle concurrency limit per second [default: disabled]
-  -burst <num>         Throttle burst max cache size [default: 100]
-  -mrelease <num>      Force OS memory release inverval in seconds [default: 30]
-  -cpus <num>          Number of used cpu cores.
-                       (default for current machine is 8 cores)
+  -a <addr>             Bind address [default: *]
+  -p <port>             Bind port [default: 8088]
+  -h, -help             Output help
+  -v, -version          Output version
+  -cors                 Enable CORS support [default: false]
+  -gzip                 Enable gzip compression [default: false]
+  -key <key>            Define API key for authorization
+  -mount <path>         Mount server directory
+  -http-cache-ttl <num> The TTL in seconds. Adds caching headers to locally served files.
+  -certfile <path>      TLS certificate file path
+  -keyfile <path>       TLS key file path
+  -concurreny <num>     Throttle concurrency limit per second [default: disabled]
+  -burst <num>          Throttle burst max cache size [default: 100]
+  -mrelease <num>       Force OS memory release inverval in seconds [default: 30]
+  -cpus <num>           Number of used cpu cores.
+                        (default for current machine is 8 cores)
 ```
 
 Start the server in a custom port
@@ -241,6 +242,13 @@ imaginary -p 8080 -concurrency 10
 Mount local directory (then you can do GET request passing the `file=image.jpg` query param)
 ```
 imaginary -p 8080 -mount ~/images
+```
+
+Send caching headers (only possible with the -mount option). The headers can be set in either "cache nothing" or 
+"cache for N seconds". By specifying 0 Imaginary will send the "don't cache" headers, otherwise it sends headers with a 
+TTL. The following example informs the client to cache the result for 1 year.
+```
+imaginary -mount ~/images -http-cache-ttl 31556926
 ```
 
 Increase libvips threads concurrency (experimental)

--- a/controllers.go
+++ b/controllers.go
@@ -46,10 +46,6 @@ func imageControllerDispatcher(o ServerOptions, operation Operation) func(http.R
 }
 
 func addCacheHeaders(w http.ResponseWriter, ttl int) {
-	if ttl < 0 {
-		return
-	}
-
 	var headerVal string
 
 	ttlDifference := time.Duration(ttl) * time.Second

--- a/imaginary.go
+++ b/imaginary.go
@@ -15,23 +15,23 @@ import (
 var debug = Debug("imaginary")
 
 var (
-	aAddr         = flag.String("a", "", "bind address")
-	aPort         = flag.Int("p", 8088, "port to listen")
-	aVers         = flag.Bool("v", false, "")
-	aVersl        = flag.Bool("version", false, "")
-	aHelp         = flag.Bool("h", false, "")
-	aHelpl        = flag.Bool("help", false, "")
-	aCors         = flag.Bool("cors", false, "")
-	aGzip         = flag.Bool("gzip", false, "")
-	aKey          = flag.String("key", "", "")
-	aMount        = flag.String("mount", "", "")
-	aCertFile     = flag.String("certfile", "", "")
-	aKeyFile      = flag.String("keyfile", "", "")
-	aHttpCacheTtl = flag.Int("http-cache-ttl", -1, "The TTL in seconds")
-	aConcurrency  = flag.Int("concurrency", 0, "")
-	aBurst        = flag.Int("burst", 100, "")
-	aMRelease     = flag.Int("mrelease", 30, "")
-	aCpus         = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
+	aAddr					= flag.String("a", "", "bind address")
+	aPort					= flag.Int("p", 8088, "port to listen")
+	aVers					= flag.Bool("v", false, "")
+	aVersl				= flag.Bool("version", false, "")
+	aHelp					= flag.Bool("h", false, "")
+	aHelpl				= flag.Bool("help", false, "")
+	aCors					= flag.Bool("cors", false, "")
+	aGzip					= flag.Bool("gzip", false, "")
+	aKey					= flag.String("key", "", "")
+	aMount				= flag.String("mount", "", "")
+	aCertFile			= flag.String("certfile", "", "")
+	aKeyFile			= flag.String("keyfile", "", "")
+	aHttpCacheTtl	= flag.Int("http-cache-ttl", -1, "The TTL in seconds")
+	aConcurrency	= flag.Int("concurrency", 0, "")
+	aBurst				= flag.Int("burst", 100, "")
+	aMRelease			= flag.Int("mrelease", 30, "")
+	aCpus					= flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
 )
 
 const usage = `imaginary server %s
@@ -79,17 +79,17 @@ func main() {
 
 	port := getPort(*aPort)
 	opts := ServerOptions{
-		Port:         port,
-		Address:      *aAddr,
-		Gzip:         *aGzip,
-		CORS:         *aCors,
-		ApiKey:       *aKey,
-		Concurrency:  *aConcurrency,
-		Burst:        *aBurst,
-		Mount:        *aMount,
-		CertFile:     *aCertFile,
-		KeyFile:      *aKeyFile,
-		HttpCacheTtl: *aHttpCacheTtl,
+		Port:					port,
+		Address:			*aAddr,
+		Gzip:					*aGzip,
+		CORS:					*aCors,
+		ApiKey:				*aKey,
+		Concurrency:	*aConcurrency,
+		Burst:				*aBurst,
+		Mount:				*aMount,
+		CertFile:			*aCertFile,
+		KeyFile:			*aKeyFile,
+		HttpCacheTtl:	*aHttpCacheTtl,
 	}
 
 	// Create a memory release goroutine

--- a/imaginary.go
+++ b/imaginary.go
@@ -3,33 +3,35 @@ package main
 import (
 	"flag"
 	"fmt"
-	. "github.com/tj/go-debug"
 	"os"
 	"runtime"
 	d "runtime/debug"
 	"strconv"
 	"time"
+
+	. "github.com/tj/go-debug"
 )
 
 var debug = Debug("imaginary")
 
 var (
-	aAddr        = flag.String("a", "", "bind address")
-	aPort        = flag.Int("p", 8088, "port to listen")
-	aVers        = flag.Bool("v", false, "")
-	aVersl       = flag.Bool("version", false, "")
-	aHelp        = flag.Bool("h", false, "")
-	aHelpl       = flag.Bool("help", false, "")
-	aCors        = flag.Bool("cors", false, "")
-	aGzip        = flag.Bool("gzip", false, "")
-	aKey         = flag.String("key", "", "")
-	aMount       = flag.String("mount", "", "")
-	aCertFile    = flag.String("certfile", "", "")
-	aKeyFile     = flag.String("keyfile", "", "")
-	aConcurrency = flag.Int("concurrency", 0, "")
-	aBurst       = flag.Int("burst", 100, "")
-	aMRelease    = flag.Int("mrelease", 30, "")
-	aCpus        = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
+	aAddr         = flag.String("a", "", "bind address")
+	aPort         = flag.Int("p", 8088, "port to listen")
+	aVers         = flag.Bool("v", false, "")
+	aVersl        = flag.Bool("version", false, "")
+	aHelp         = flag.Bool("h", false, "")
+	aHelpl        = flag.Bool("help", false, "")
+	aCors         = flag.Bool("cors", false, "")
+	aGzip         = flag.Bool("gzip", false, "")
+	aKey          = flag.String("key", "", "")
+	aMount        = flag.String("mount", "", "")
+	aCertFile     = flag.String("certfile", "", "")
+	aKeyFile      = flag.String("keyfile", "", "")
+	aHttpCacheTtl = flag.Int("http-cache-ttl", -1, "The TTL in seconds")
+	aConcurrency  = flag.Int("concurrency", 0, "")
+	aBurst        = flag.Int("burst", 100, "")
+	aMRelease     = flag.Int("mrelease", 30, "")
+	aCpus         = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
 )
 
 const usage = `imaginary server %s
@@ -41,21 +43,22 @@ Usage:
   imaginary -v | -version
 
 Options:
-  -a <addr>            bind address [default: *]
-  -p <port>            bind port [default: 8088]
-  -h, -help            output help
-  -v, -version         output version
-  -cors                Enable CORS support [default: false]
-  -gzip                Enable gzip compression [default: false]
-  -key <key>           Define API key for authorization
-  -mount <path>        Mount server directory
-  -certfile <path>     TLS certificate file path
-  -keyfile <path>      TLS key file path
-  -concurreny <num>    Throttle concurrency limit per second [default: disabled]
-  -burst <num>         Throttle burst max cache size [default: 100]
-  -mrelease <num>      Force OS memory release inverval in seconds [default: 30]
-  -cpus <num>          Number of used cpu cores.
-                       (default for current machine is %d cores)
+  -a <addr>             bind address [default: *]
+  -p <port>             bind port [default: 8088]
+  -h, -help             output help
+  -v, -version          output version
+  -cors                 Enable CORS support [default: false]
+  -gzip                 Enable gzip compression [default: false]
+  -key <key>            Define API key for authorization
+  -mount <path>         Mount server directory
+  -http-cache-ttl <num> The TTL in seconds. Adds caching headers to locally served files.
+  -certfile <path>      TLS certificate file path
+  -keyfile <path>       TLS key file path
+  -concurreny <num>     Throttle concurrency limit per second [default: disabled]
+  -burst <num>          Throttle burst max cache size [default: 100]
+  -mrelease <num>       Force OS memory release inverval in seconds [default: 30]
+  -cpus <num>           Number of used cpu cores.
+                        (default for current machine is %d cores)
 `
 
 func main() {
@@ -76,16 +79,17 @@ func main() {
 
 	port := getPort(*aPort)
 	opts := ServerOptions{
-		Port:        port,
-		Address:     *aAddr,
-		Gzip:        *aGzip,
-		CORS:        *aCors,
-		ApiKey:      *aKey,
-		Concurrency: *aConcurrency,
-		Burst:       *aBurst,
-		Mount:       *aMount,
-		CertFile:    *aCertFile,
-		KeyFile:     *aKeyFile,
+		Port:         port,
+		Address:      *aAddr,
+		Gzip:         *aGzip,
+		CORS:         *aCors,
+		ApiKey:       *aKey,
+		Concurrency:  *aConcurrency,
+		Burst:        *aBurst,
+		Mount:        *aMount,
+		CertFile:     *aCertFile,
+		KeyFile:      *aKeyFile,
+		HttpCacheTtl: *aHttpCacheTtl,
 	}
 
 	// Create a memory release goroutine

--- a/imaginary.go
+++ b/imaginary.go
@@ -102,6 +102,10 @@ func main() {
 		checkMountDirectory(*aMount)
 	}
 
+	if *aHttpCacheTtl != -1 {
+		checkHttpCacheTtl(*aHttpCacheTtl)
+	}
+
 	debug("imaginary server listening on port %d", port)
 
 	err := Server(opts)
@@ -140,6 +144,17 @@ func checkMountDirectory(path string) {
 	if src.IsDir() == false {
 		fmt.Fprintf(os.Stderr, "mount path is not a directory: %s\n", err)
 		os.Exit(1)
+	}
+}
+
+func checkHttpCacheTtl(ttl int) {
+	if ttl < -1 || ttl > 31556926 {
+		fmt.Fprintln(os.Stderr, "The -http-cache-ttl flag accepts a value from 0 to 31556926")
+		os.Exit(1)
+	}
+
+	if ttl == 0 {
+		debug("Adding HTTP cache control headers set to prevent caching.")
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -8,16 +8,17 @@ import (
 )
 
 type ServerOptions struct {
-	Port        int
-	CORS        bool
-	Gzip        bool
-	Address     string
-	ApiKey      string
-	Mount       string
-	CertFile    string
-	KeyFile     string
-	Burst       int
-	Concurrency int
+	Port         int
+	CORS         bool
+	Gzip         bool
+	Address      string
+	ApiKey       string
+	Mount        string
+	CertFile     string
+	KeyFile      string
+	Burst        int
+	Concurrency  int
+	HttpCacheTtl int
 }
 
 func Server(o ServerOptions) error {

--- a/server.go
+++ b/server.go
@@ -8,17 +8,17 @@ import (
 )
 
 type ServerOptions struct {
-	Port         int
-	CORS         bool
-	Gzip         bool
-	Address      string
-	ApiKey       string
-	Mount        string
-	CertFile     string
-	KeyFile      string
-	Burst        int
-	Concurrency  int
-	HttpCacheTtl int
+	Port					int
+	CORS					bool
+	Gzip					bool
+	Address				string
+	ApiKey				string
+	Mount					string
+	CertFile			string
+	KeyFile				string
+	Burst					int
+	Concurrency		int
+	HttpCacheTtl	int
 }
 
 func Server(o ServerOptions) error {
@@ -26,11 +26,11 @@ func Server(o ServerOptions) error {
 	handler := NewLog(NewServerMux(o), os.Stdout)
 
 	server := &http.Server{
-		Addr:           addr,
-		Handler:        handler,
-		ReadTimeout:    60 * time.Second,
-		WriteTimeout:   60 * time.Second,
-		MaxHeaderBytes: 1 << 20,
+		Addr:						addr,
+		Handler:				handler,
+		ReadTimeout:		60 * time.Second,
+		WriteTimeout:		60 * time.Second,
+		MaxHeaderBytes:	1 << 20,
 	}
 
 	return listenAndServe(server, o)


### PR DESCRIPTION
This PR adds the flag `-http-cache-ttl` (in seconds). It will then add the following headers for all GET requests (thus it requires a -mount to be specified also)

 - Cache-Control: public, s-max-age: 123456, max-age: 123456, no-transform
 - Expires: time.Now().Add(..duration)

Example command:
`./imaginary -mount fixtures/ -http-cache-ttl=31556926`

Example headers for a request:
```
HTTP/1.1 200 OK
Cache-Control: public, s-maxage: 31556926, max-age: 31556926, no-transform
Content-Type: image/jpeg
Expires: Mon, 31 Oct 2016 01:55:28 UTC
Server: imaginary 0.1.16 (bimg 0.1.21)
Date: Sat, 31 Oct 2015 20:06:42 GMT
Transfer-Encoding: chunked
```

The flag `-http-cache-ttl` supports a value of 0-31556926. The value 0 sends caching headers that inform the clients that no caching should be performed. The maximum supported value is 31556926, as this is the maximum recommended value (according to RFC2616).