### PR TITLE
Added the CA certs so that the --insecure flag can be removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ ENV GOLANG_VERSION 1.5
 
 # gcc for cgo
 RUN apt-get update && apt-get install -y \
-    gcc curl git libc6-dev make \
+    gcc curl git libc6-dev make ca-certificates \
     --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOLANG_DOWNLOAD_SHA1 5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a
 
-RUN curl -fsSL --insecure "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
   && echo "$GOLANG_DOWNLOAD_SHA1 golang.tar.gz" | sha1sum -c - \
   && tar -C /usr/local -xzf golang.tar.gz \
   && rm golang.tar.gz


### PR DESCRIPTION
It's a minor change, and the package is being validated with a checksum. But personally this felt a little more comforting. This change introduces 5.5MiB (was: 921.5 MiB, becomes: 926 MiB) to the virtual image size.