### PR TITLE
Fix PORT environment variable in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ RUN go get -u github.com/h2non/imaginary
 ENTRYPOINT ["/go/bin/imaginary"]
 
 # Expose the server TCP port
-EXPOSE 9000
+EXPOSE $PORT


### PR DESCRIPTION
The environment variable PORT is unused in dockerfile and always expose the default port 9000