### PR TITLE
Add `path-prefix` flag to bind to an url path

### DIFF
--- a/imaginary.go
+++ b/imaginary.go
@@ -23,6 +23,7 @@ var (
 	aVersl           = flag.Bool("version", false, "Show version")
 	aHelp            = flag.Bool("h", false, "Show help")
 	aHelpl           = flag.Bool("help", false, "Show help")
+	aPathPrefix      = flag.String("path-prefix", "/", "Url path prefix to listen to")
 	aCors            = flag.Bool("cors", false, "Enable CORS support")
 	aGzip            = flag.Bool("gzip", false, "Enable gzip compression")
 	aAuthForwarding  = flag.Bool("enable-auth-forwarding", false, "Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors")
@@ -48,6 +49,7 @@ Usage:
   imaginary -p 80
   imaginary -cors -gzip
   imaginary -concurrency 10
+  imaginary -path-prefix /api/v1
   imaginary -enable-url-source
   imaginary -enable-url-source -allowed-origins http://localhost,http://server.com
   imaginary -enable-url-source -enable-auth-forwarding
@@ -60,6 +62,7 @@ Options:
   -p <port>                 bind port [default: 8088]
   -h, -help                 output help
   -v, -version              output version
+  -path-prefix <value>      Url path prefix to listen to [default: "/"]
   -cors                     Enable CORS support [default: false]
   -gzip                     Enable gzip compression [default: false]
   -key <key>                Define API key for authorization
@@ -104,6 +107,7 @@ func main() {
 		CORS:             *aCors,
 		AuthForwarding:   *aAuthForwarding,
 		EnableURLSource:  *aEnableURLSource,
+		PathPrefix:       *aPathPrefix,
 		ApiKey:           *aKey,
 		Concurrency:      *aConcurrency,
 		Burst:            *aBurst,
@@ -132,7 +136,7 @@ func main() {
 		checkHttpCacheTtl(*aHttpCacheTtl)
 	}
 
-	debug("imaginary server listening on port %d", port)
+	debug("imaginary server listening on port :%d/%s", opts.Port, strings.TrimPrefix(opts.PathPrefix, "/"))
 
 	// Load image source providers
 	LoadSources(opts)

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"time"
 )
@@ -20,6 +21,7 @@ type ServerOptions struct {
 	EnableURLSource  bool
 	AuthForwarding   bool
 	Address          string
+	PathPrefix       string
 	ApiKey           string
 	Mount            string
 	CertFile         string
@@ -53,23 +55,23 @@ func listenAndServe(s *http.Server, o ServerOptions) error {
 func NewServerMux(o ServerOptions) http.Handler {
 	mux := http.NewServeMux()
 
-	mux.Handle("/", Middleware(indexController, o))
-	mux.Handle("/form", Middleware(formController, o))
-	mux.Handle("/health", Middleware(healthController, o))
+	mux.Handle(path.Join(o.PathPrefix, "/"), Middleware(indexController, o))
+	mux.Handle(path.Join(o.PathPrefix, "/form"), Middleware(formController, o))
+	mux.Handle(path.Join(o.PathPrefix, "/health"), Middleware(healthController, o))
 
 	image := ImageMiddleware(o)
-	mux.Handle("/resize", image(Resize))
-	mux.Handle("/enlarge", image(Enlarge))
-	mux.Handle("/extract", image(Extract))
-	mux.Handle("/crop", image(Crop))
-	mux.Handle("/rotate", image(Rotate))
-	mux.Handle("/flip", image(Flip))
-	mux.Handle("/flop", image(Flop))
-	mux.Handle("/thumbnail", image(Thumbnail))
-	mux.Handle("/zoom", image(Zoom))
-	mux.Handle("/convert", image(Convert))
-	mux.Handle("/watermark", image(Watermark))
-	mux.Handle("/info", image(Info))
+	mux.Handle(path.Join(o.PathPrefix, "/resize"), image(Resize))
+	mux.Handle(path.Join(o.PathPrefix, "/enlarge"), image(Enlarge))
+	mux.Handle(path.Join(o.PathPrefix, "/extract"), image(Extract))
+	mux.Handle(path.Join(o.PathPrefix, "/crop"), image(Crop))
+	mux.Handle(path.Join(o.PathPrefix, "/rotate"), image(Rotate))
+	mux.Handle(path.Join(o.PathPrefix, "/flip"), image(Flip))
+	mux.Handle(path.Join(o.PathPrefix, "/flop"), image(Flop))
+	mux.Handle(path.Join(o.PathPrefix, "/thumbnail"), image(Thumbnail))
+	mux.Handle(path.Join(o.PathPrefix, "/zoom"), image(Zoom))
+	mux.Handle(path.Join(o.PathPrefix, "/convert"), image(Convert))
+	mux.Handle(path.Join(o.PathPrefix, "/watermark"), image(Watermark))
+	mux.Handle(path.Join(o.PathPrefix, "/info"), image(Info))
 
 	return mux
 }


### PR DESCRIPTION
This PR adds a configurable path-prefix, which allows listening to a url like `*:9000/api/v1/imaginary/info`