### PR TITLE
Remove the .godir as Heroku and Cloud Foundry remove the support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ bin/imaginary
 
 ## ignore vendor packages
 vendor/
+glide.lock

--- a/.godir
+++ b/.godir
@@ -1,1 +1,0 @@
-imaginary


### PR DESCRIPTION
1. Remove the .godir file as Hero go buildpack remove the support.
For the details, pls reference [here](https://github.com/heroku/heroku-buildpack-go/blob/d21f5d37c9a7ca59349d6bb3a55aa1eb3607b570/CHANGELOG.md#v23-2015-12-17)
2. Ignore the glide.lock