### PR TITLE
Mapping Blur URL params to the ImageOptions struct fields

### DIFF
--- a/controllers.go
+++ b/controllers.go
@@ -116,6 +116,7 @@ func formController(w http.ResponseWriter, r *http.Request) {
 		{"Add watermark", "watermark", "textwidth=100&text=Hello&font=sans%2012&opacity=0.5&color=255,200,50"},
 		{"Convert format", "convert", "type=png"},
 		{"Image metadata", "info", ""},
+		{"Gaussian blur", "blur", "sigma=15.0&minampl=0.2"},
 	}
 
 	html := "<html><body>"

--- a/params.go
+++ b/params.go
@@ -40,6 +40,8 @@ var allowedParams = map[string]string{
 	"gravity":     "gravity",
 	"background":  "color",
 	"extend":      "extend",
+	"sigma":       "float",
+	"minampl":     "float",
 }
 
 func readParams(query url.Values) ImageOptions {
@@ -109,6 +111,8 @@ func mapImageParams(params map[string]interface{}) ImageOptions {
 		Gravity:     params["gravity"].(bimg.Gravity),
 		Colorspace:  params["colorspace"].(bimg.Interpretation),
 		Background:  params["background"].([]uint8),
+		Sigma:       params["sigma"].(float64),
+		MinAmpl:     params["minampl"].(float64),
 	}
 }
 


### PR DESCRIPTION
@h2non I missed these changes for the Blur features. These are required in order for it to work.