### PR TITLE
Convert docker build to more efficient multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM ubuntu:16.04
+FROM ubuntu:16.04 as builder
 MAINTAINER tomas@aparicio.me
 
 ENV LIBVIPS_VERSION 8.5.6
@@ -14,7 +14,7 @@ RUN \
   automake build-essential curl \
   gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg-turbo8-dev libpng12-dev \
   libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev \
-  swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio3-dev \
+  swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev \
   libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev && \
 
   # Build libvips
@@ -69,6 +69,29 @@ COPY . $GOPATH/src/github.com/h2non/imaginary
 
 # Compile imaginary
 RUN go build -race -o bin/imaginary github.com/h2non/imaginary
+
+FROM ubuntu:16.04
+
+RUN \
+  # Install runtime dependencies
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  libglib2.0-0 libjpeg-turbo8 libpng12-0 libopenexr22 \
+  libwebp5 libtiff5 libgif7 libexif12 libxml2 libpoppler-glib8 \
+  libmagickwand-6.q16-2 libpango1.0-0 libmatio2 libopenslide0 \
+  libgsf-1-114 fftw3 liborc-0.4 librsvg2-2 libcfitsio2 && \
+  # Clean up
+  apt-get autoremove -y && \
+  apt-get autoclean && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /usr/local/lib /usr/local/lib
+RUN ldconfig
+COPY --from=builder /go/bin/imaginary bin/
+
+# Server port to listen
+ENV PORT 9000
 
 # Run the entrypoint command by default when the container starts.
 ENTRYPOINT ["bin/imaginary"]


### PR DESCRIPTION
The existing Docker build takes quite a while and produces a big image:
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
a96932dc542c        3 minutes ago       /bin/sh -c #(nop)  EXPOSE 9000                  0B                  
cceefd88c782        3 minutes ago       /bin/sh -c #(nop)  ENTRYPOINT ["bin/imagin...   0B                  
6c4eee9ed704        3 minutes ago       /bin/sh -c go build -race -o bin/imaginary...   9.93MB              
6b3a6b0daf60        3 minutes ago       /bin/sh -c #(nop) COPY dir:c4ac65197153438...   22.9MB              
7b18991f7270        3 minutes ago       /bin/sh -c go get -u github.com/golang/dep...   38.8MB              
4d302f9420be        4 minutes ago       /bin/sh -c go get -u golang.org/x/net/context   15MB                
120c185ddbfc        4 minutes ago       /bin/sh -c #(nop) WORKDIR /go                   0B                  
04f48dafab3c        4 minutes ago       /bin/sh -c mkdir -p "$GOPATH/src" "$GOPATH...   0B                  
bd1dfce9fe59        4 minutes ago       /bin/sh -c #(nop)  ENV PATH=/go/bin:/usr/l...   0B                  
e346d6c45686        4 minutes ago       /bin/sh -c #(nop)  ENV GOPATH=/go               0B                  
11ad25abd268        4 minutes ago       /bin/sh -c curl -fsSL --insecure "$GOLANG_...   298MB               
adddd3a5bf70        5 minutes ago       /bin/sh -c #(nop)  ENV GOLANG_DOWNLOAD_SHA...   0B                  
fc4aaee59595        5 minutes ago       /bin/sh -c #(nop)  ENV GOLANG_DOWNLOAD_URL...   0B                  
4d531cc783f5        5 minutes ago       /bin/sh -c apt-get update && apt-get insta...   32MB                
874333b2c271        5 minutes ago       /bin/sh -c #(nop)  ENV GOLANG_VERSION=1.9.2     0B                  
990537a1cfbc        5 minutes ago       /bin/sh -c #(nop)  ENV PORT=9000                0B                  
e67b71924f30        5 minutes ago       /bin/sh -c apt-get update &&   DEBIAN_FRON...   594MB               
182ab48a7862        10 minutes ago      /bin/sh -c #(nop)  ENV LIBVIPS_VERSION=8.5.6    0B                  
6885853b8519        10 minutes ago      /bin/sh -c #(nop)  MAINTAINER tomas@aparic...   0B                  
dd6f76d9cc90        6 days ago          /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
<missing>           6 days ago          /bin/sh -c mkdir -p /run/systemd && echo '...   7B                  
<missing>           6 days ago          /bin/sh -c sed -i 's/^#\s*\(deb.*universe\...   2.76kB              
<missing>           6 days ago          /bin/sh -c rm -rf /var/lib/apt/lists/*          0B                  
<missing>           6 days ago          /bin/sh -c set -xe   && echo '#!/bin/sh' >...   745B                
<missing>           6 days ago          /bin/sh -c #(nop) ADD file:5b334adf9d9a225...   122MB               
```

This alpine based multi-stage Dockerfile produces this image:
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
a16e5e859f98        4 minutes ago       /bin/sh -c #(nop)  EXPOSE 9000                  0B                  
e435bcf81b6a        4 minutes ago       /bin/sh -c #(nop)  ENTRYPOINT ["bin/imagin...   0B                  
2230c124ec2e        4 minutes ago       /bin/sh -c #(nop)  ENV PORT=9000                0B                  
203d2faf06a5        4 minutes ago       /bin/sh -c #(nop) COPY file:16d89547f80183...   9.55MB              
20c814649def        4 days ago          /bin/sh -c apk add --update --no-cache  --...   19.1MB              
72dfe9e82e16        6 days ago          /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B                  
<missing>           6 days ago          /bin/sh -c #(nop) ADD file:682bfba4bfda1ed...   4.15MB         
```
(see https://docs.docker.com/engine/userguide/eng-image/multistage-build/ for more info about multi stage builds and their advantages)

The alpine build takes 35s on my desktop, the existing ubuntu one over 10minutes!

One caveat worth noting is because we're using alpine packages for libvips and golang this ties the build to the alpine releases (currently libvips 8.5.8, golang 1.9.2 - they're pretty good at staying up to date). Hopefully the speed of build and minimal size of resulting image outweigh this?