### PR TITLE
Add /fit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To get started, take a look the [installation](#installation) steps, [usage](#us
 - Flop
 - Zoom
 - Thumbnail
+- Fit
 - [Pipeline](#get--post-pipeline) of multiple independent image transformations in a single HTTP request.
 - Configurable image area extraction
 - Embed/Extend image, supporting multiple modes (white, black, mirror, copy or custom background color)
@@ -738,6 +739,36 @@ Accepts: `image/*, multipart/form-data`. Content-Type: `image/*`
 
 - width `int`
 - height `int`
+- quality `int` (JPEG-only)
+- compression `int` (PNG-only)
+- type `string`
+- file `string` - Only GET method and if the `-mount` flag is present
+- url `string` - Only GET method and if the `-enable-url-source` flag is present
+- embed `bool`
+- force `bool`
+- rotate `int`
+- norotation `bool`
+- noprofile `bool`
+- stripmeta `bool`
+- flip `bool`
+- flop `bool`
+- extend `string`
+- background `string` - Example: `?background=250,20,10`
+- colorspace `string`
+- sigma `float`
+- minampl `float`
+- field `string` - Only POST and `multipart/form` payloads
+
+#### GET | POST /fit
+Accepts: `image/*, multipart/form-data`. Content-Type: `image/*`
+
+Resize an image to fit within width and height, without cropping. Image aspect ratio is maintained
+The width and height specify a maximum bounding box for the image.
+
+##### Allowed params
+
+- width `int` `required`
+- height `int` `required`
 - quality `int` (JPEG-only)
 - compression `int` (PNG-only)
 - type `string`

--- a/image_test.go
+++ b/image_test.go
@@ -21,6 +21,23 @@ func TestImageResize(t *testing.T) {
 	}
 }
 
+func TestImageFit(t *testing.T) {
+	opts := ImageOptions{Width: 300, Height: 300}
+	buf, _ := ioutil.ReadAll(readFile("imaginary.jpg"))
+
+	img, err := Fit(buf, opts)
+	if err != nil {
+		t.Errorf("Cannot process image: %s", err)
+	}
+	if img.Mime != "image/jpeg" {
+		t.Error("Invalid image MIME type")
+	}
+	// 550x740 -> 222x300
+	if assertSize(img.Body, 222, 300) != nil {
+		t.Errorf("Invalid image size, expected: %dx%d", opts.Width, opts.Height)
+	}
+}
+
 func TestImagePipelineOperations(t *testing.T) {
 	width, height := 300, 260
 

--- a/server.go
+++ b/server.go
@@ -87,6 +87,7 @@ func NewServerMux(o ServerOptions) http.Handler {
 
 	image := ImageMiddleware(o)
 	mux.Handle(join(o, "/resize"), image(Resize))
+	mux.Handle(join(o, "/fit"), image(Fit))
 	mux.Handle(join(o, "/enlarge"), image(Enlarge))
 	mux.Handle(join(o, "/extract"), image(Extract))
 	mux.Handle(join(o, "/crop"), image(Crop))

--- a/server_test.go
+++ b/server_test.go
@@ -173,6 +173,39 @@ func TestExtract(t *testing.T) {
 	}
 }
 
+func TestFit(t *testing.T) {
+	ts := testServer(controller(Fit))
+	buf := readFile("large.jpg")
+	url := ts.URL + "?width=300&height=300"
+	defer ts.Close()
+
+	res, err := http.Post(url, "image/jpeg", buf)
+	if err != nil {
+		t.Fatal("Cannot perform the request")
+	}
+
+	if res.StatusCode != 200 {
+		t.Fatalf("Invalid response status: %s", res.Status)
+	}
+
+	image, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(image) == 0 {
+		t.Fatalf("Empty response body")
+	}
+
+	err = assertSize(image, 300, 168)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if bimg.DetermineImageTypeName(image) != "jpeg" {
+		t.Fatalf("Invalid image type")
+	}
+}
+
 func TestRemoteHTTPSource(t *testing.T) {
 	opts := ServerOptions{EnableURLSource: true}
 	fn := ImageMiddleware(opts)(Crop)


### PR DESCRIPTION
This adds a /fit action which sizes the image to a bounding box, preserving aspect, without cropping.
issues #135, #139

We needed this in migrating our image flow - where we wouldn't have the ability to add the logic client side.
(Apologies for the flurry of pull requests today, just clearing up our fork - feel free to take your time :-) )