### PR TITLE
Add Docker Compose note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,18 @@ You can see all the Docker tags [here](https://hub.docker.com/r/h2non/imaginary/
 Alternatively you may add imaginary to your `docker-compose.yml` file:
 
 ```yaml
-imaginary:
-  image: h2non/imaginary
-  ports:
-    - "8088:8088"
-  environment:
-    - PORT=8088
-  command: -concurrency 20 -enable-url-source
+version: "3"
+services:
+  imaginary:
+    image: h2non/imaginary:latest
+    # optionally mount a volume as local image source
+    volumes:
+      - images:/mnt/data
+    environment:
+       PORT: 9000
+    command: -enable-url-source -mount /mnt/data
+    ports:
+      - "9000:9000"
 ```
 
 ### Heroku

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ docker stop h2non/imaginary
 
 You can see all the Docker tags [here](https://hub.docker.com/r/h2non/imaginary/tags/).
 
+Alternatively you may add imaginary to your `docker-compose.yml` file:
+
+```yaml
+imaginary:
+  image: h2non/imaginary
+  ports:
+    - "8088:8088"
+  environment:
+    - PORT=8088
+  command: -concurrency 20 -enable-url-source
+```
+
 ### Heroku
 
 Click on the Heroku button to easily deploy your app:


### PR DESCRIPTION
It might be nice to have a ready to go snippet for `docker-compose.yml` files.

It's a minimal example, maybe it would be helpful to show how to mount a local Docker volume as well?