### PR TITLE
feat(Docker): upgrade libvips to v8.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.9
-  - 1.8
-  - 1.7
-  - 1.6
-  - tip
+  - "1.10"
+  - "1.9"
+  - "1.8"
+  - "1.7"
+  - "1.6"
+  - "tip"
 
 env:
   - LIBVIPS=7.42
@@ -16,6 +17,7 @@ env:
   - LIBVIPS=8.3
   - LIBVIPS=8.4
   - LIBVIPS=8.5
+  - LIBVIPS=8.6
   - LIBVIPS=master
 
 matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:16.04 as builder
 MAINTAINER tomas@aparicio.me
 
-ENV LIBVIPS_VERSION 8.5.6
+ENV LIBVIPS_VERSION 8.6.2
 
 # Installs libvips + required libraries
 RUN \


### PR DESCRIPTION
Update libipvs in Dockerfile to the [latest stable version](https://github.com/jcupitt/libvips/releases/tag/v8.6.2).