### PR TITLE
Uniform build refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 2
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yml]
+indent_style = space

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,41 @@
+{
+  "Cyclo": 10,
+  "Deadline": "5m",
+  "Vendor": true,
+  "Test": true,
+  "EnableAll": false,
+  "Checkstyle": true,
+  "Errors": true,
+  "Enable": [
+    "deadcode",
+    "dupl",
+    "errcheck",
+    "gochecknoglobals",
+    "gochecknoinits",
+    "goconst",
+    "gofmt",
+    "goimports",
+    "golint",
+    "gosec",
+    "ineffassign",
+    "interfacer",
+    "megacheck",
+    "misspell",
+    "nakedret",
+    "test",
+    "testify",
+    "unconvert",
+    "unparam",
+    "vetshadow"
+  ],
+  "Disable": [
+    "gotype",
+    "errcheck",
+    "gosec disabled for now",
+    "gosec_"
+  ],
+  "Exclude": [
+    "Errors unhandled",
+    "Potential file inclusion via variable"
+  ]
+}

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -4,8 +4,8 @@
   "Vendor": true,
   "Test": true,
   "EnableAll": false,
-  "Checkstyle": true,
-  "Errors": true,
+  "Checkstyle": false,
+  "Errors": false,
   "Enable": [
     "deadcode",
     "dupl",
@@ -14,6 +14,7 @@
     "gochecknoinits",
     "goconst",
     "gofmt",
+    "gotypex",
     "goimports",
     "golint",
     "gosec",
@@ -26,16 +27,19 @@
     "testify",
     "unconvert",
     "unparam",
-    "vetshadow"
+    "vetshadow",
+    "staticcheck"
   ],
   "Disable": [
-    "gotype",
-    "errcheck",
-    "gosec disabled for now",
-    "gosec_"
+    "gochecknoglobals",
+    "gochecknoinits",
+    "dupl"
   ],
   "Exclude": [
+    "vendor/.*",
+    "by package bimg",
     "Errors unhandled",
-    "Potential file inclusion via variable"
+    "Potential file inclusion via variable",
+    "should have comment"
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 
-sudo: required
+services:
+  - docker
+
 dist: trusty
 
 go:
@@ -9,63 +11,23 @@ go:
   - "tip"
 
 env:
-  - LIBVIPS=7.42
-  - LIBVIPS=8.2
-  - LIBVIPS=8.3
-  - LIBVIPS=8.4
-  - LIBVIPS=8.5
-  - LIBVIPS=8.6
-  - LIBVIPS=8.7
-  - LIBVIPS=master
+  global:
+    - IMAGINARY_VERSION=${TRAVIS_TAG:-"dev"}
+    - DCMD="docker run --rm -i -v ${TRAVIS_BUILD_DIR}:/go/src/github/h2non/imaginary -w /go/src/github/h2non/imaginary h2non/imaginary:build"
+  matrix:
+    - LIBVIPS=8.7.2
+    - LIBVIPS=master
 
 matrix:
   allow_failures:
-    - env: LIBVIPS=7.42
-    - env: LIBVIPS=8.2
-    - env: LIBVIPS=8.3
     - env: LIBVIPS=master
-
-cache: apt
-
-addons:
-  apt:
-    packages:
-      - gobject-introspection
-      - gtk-doc-tools
-      - libcfitsio3-dev
-      - libfftw3-dev
-      - libgif-dev
-      - libgs-dev
-      - libgsf-1-dev
-      - libmatio-dev
-      - libopenslide-dev
-      - liborc-0.4-dev
-      - libpango1.0-dev
-      - libpoppler-glib-dev
-      - libwebp-dev
+    - go: "tip"
 
 before_install:
-  - wget https://github.com/libvips/libvips/archive/$LIBVIPS.zip
-  - unzip $LIBVIPS
-  - cd libvips-$LIBVIPS
-  - test -f autogen.sh && ./autogen.sh || ./bootstrap.sh
-  - >
-    CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0
-    ./configure
-    --disable-debug
-    --disable-dependency-tracking
-    --disable-introspection
-    --disable-static
-    --enable-gtk-doc-html=no
-    --enable-gtk-doc=no
-    --enable-pyvips8=no
-    --without-orc
-    --without-python
-    $1
-  - make
-  - sudo make install
-  - sudo ldconfig
+  - true
+
+install:
+  - true
 
 script:
-  - cd ..
-  - go test -v -race -covermode=atomic
+  - echo "go test -v -race -covermode=atomic" | ${DCMD}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,82 +1,56 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM ubuntu:16.04 as builder
-MAINTAINER tomas@aparicio.me
+FROM h2non/bimg:build as builder
 
-ENV LIBVIPS_VERSION 8.7.0
+ARG GO_VERSION
+ARG LIBVIPS_VERSION
+ARG BIMG_VERSION
+ARG IMAGINARY_VERSION="dev"
 
-# Installs libvips + required libraries
-RUN \
-
-  # Install dependencies
-  apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  ca-certificates \
-  automake build-essential curl \
-  gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg-turbo8-dev libpng12-dev \
-  libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev \
-  swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev \
-  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev && \
-
-  # Build libvips
-  cd /tmp && \
-  curl -OL https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.gz && \
-  tar zvxf vips-${LIBVIPS_VERSION}.tar.gz && \
-  cd /tmp/vips-${LIBVIPS_VERSION} && \
-  ./configure --enable-debug=no --without-python $1 && \
-  make && \
-  make install && \
-  ldconfig && \
-
-  # Clean up
-  apt-get remove -y curl automake build-essential && \
-  apt-get autoremove -y && \
-  apt-get autoclean && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Server port to listen
-ENV PORT 9000
-
-# Go version to use
-ENV GOLANG_VERSION 1.11.2
-
-# gcc for cgo
-RUN apt-get update && apt-get install -y \
-    gcc curl git libc6-dev make \
-    --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/*
-
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d
-
-RUN curl -fsSL --insecure "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
-  && echo "$GOLANG_DOWNLOAD_SHA256 golang.tar.gz" | sha256sum -c - \
-  && tar -C /usr/local -xzf golang.tar.gz \
-  && rm golang.tar.gz
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV PATH ${GOPATH}/bin:/usr/local/go/bin:${PATH}
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-WORKDIR $GOPATH
+# Installing gometalinter
+WORKDIR /tmp
+RUN curl -fsSL https://git.io/vp6lP -o instgm.sh && chmod u+x instgm.sh && ./instgm.sh -b "${GOPATH}/bin"
 
-# Fetch the latest version of the package
-RUN go get -u golang.org/x/net/context
-RUN go get -u github.com/golang/dep/cmd/dep
+WORKDIR ${GOPATH}/src/github.com/h2non/imaginary
 
 # Copy imaginary sources
-COPY . $GOPATH/src/github.com/h2non/imaginary
+COPY . .
+
+# Making sure all dependencies are up-to-date
+RUN dep ensure
+
+# Run quality control
+RUN go test -test.v ./...
+RUN gometalinter github.com/h2non/imaginary
 
 # Compile imaginary
-RUN go build -o bin/imaginary github.com/h2non/imaginary
+RUN go build -a \
+    -o $GOPATH/bin/imaginary \
+    -ldflags="-h -X main.Version=${IMAGINARY_VERSION}" \
+    github.com/h2non/imaginary
 
 FROM ubuntu:16.04
 
-RUN \
-  # Install runtime dependencies
-  apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+ARG IMAGINARY_VERSION
+
+LABEL maintainer="tomas@aparicio.me" \
+      org.label-schema.description="Fast, simple, scalable HTTP microservice for high-level image processing with first-class Docker support" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.url="https://github.com/h2non/imaginary" \
+      org.label-schema.vcs-url="https://github.com/h2non/imaginary" \
+      org.label-schema.version="${IMAGINARY_VERSION}"
+
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /go/bin/imaginary /usr/local/bin/imaginary
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
+# Install runtime dependencies
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+  apt-get install --no-install-recommends -y \
   libglib2.0-0 libjpeg-turbo8 libpng12-0 libopenexr22 \
   libwebp5 libtiff5 libgif7 libexif12 libxml2 libpoppler-glib8 \
   libmagickwand-6.q16-2 libpango1.0-0 libmatio2 libopenslide0 \
@@ -87,16 +61,11 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY --from=builder /usr/local/lib /usr/local/lib
-RUN ldconfig
-COPY --from=builder /go/bin/imaginary bin/
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-
 # Server port to listen
 ENV PORT 9000
 
 # Run the entrypoint command by default when the container starts.
-ENTRYPOINT ["bin/imaginary"]
+ENTRYPOINT ["/usr/local/bin/imaginary"]
 
 # Expose the server TCP port
-EXPOSE 9000
+EXPOSE ${PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM h2non/bimg:build as builder
+FROM h2non/imaginary:build as builder
 
-ARG GO_VERSION
-ARG LIBVIPS_VERSION
-ARG BIMG_VERSION
 ARG IMAGINARY_VERSION="dev"
-
 
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:/usr/local/go/bin:${PATH}
@@ -21,7 +15,7 @@ WORKDIR ${GOPATH}/src/github.com/h2non/imaginary
 COPY . .
 
 # Making sure all dependencies are up-to-date
-RUN dep ensure
+RUN rm -rf vendor && dep ensure
 
 # Run quality control
 RUN go test -test.v ./...

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,13 +22,12 @@
 
 [[constraint]]
   name = "github.com/rs/cors"
+  version = "^1.2"
 
 [[constraint]]
   name = "gopkg.in/h2non/bimg.v1"
   version = "^1.0"
 
 [[constraint]]
-  name = "gopkg.in/h2non/filetype.v1"
-
-[[constraint]]
   name = "gopkg.in/throttled/throttled.v2"
+  version = "^2.0"

--- a/controllers.go
+++ b/controllers.go
@@ -18,7 +18,11 @@ func indexController(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, _ := json.Marshal(CurrentVersions)
+	body, _ := json.Marshal(Versions{
+		Version,
+		bimg.Version,
+		bimg.VipsVersion,
+	})
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(body)
 }

--- a/version.go
+++ b/version.go
@@ -1,9 +1,7 @@
 package main
 
-import "gopkg.in/h2non/bimg.v1"
-
 // Version stores the current package semantic version
-const Version = "1.0.17"
+var Version = "dev"
 
 // Versions represents the used versions for several significant dependencies
 type Versions struct {
@@ -11,6 +9,3 @@ type Versions struct {
 	BimgVersion      string `json:"bimg"`
 	VipsVersion      string `json:"libvips"`
 }
-
-// CurrentVersions stores the current runtime system version metadata
-var CurrentVersions = Versions{Version, bimg.Version, bimg.VipsVersion}


### PR DESCRIPTION
# Status
Ready for review.

- [ ] Collecting feedback
- [x] Creating a first workable version
- [x] Update CI config to use Docker containers for building
- [ ] ~Switch to auto-build Docker images on Docker Hub~ _(Not sure if this is desired / a good idea)_
- [ ] Updating documentation
- [x] Update this PR until it's ready enough for review
- [ ] ~Produce a Docker image of around 93MiB (as is currently the size)~ _(The compressed image is actually smaller than the current, but not as small as we'd like. However to not delay this PR much further I suggest to delay this requirement)._

# Typical use cases
## Creating a new Docker image / release
```sh
$ docker build -t myLabel:latest --build-arg IMAGINARY_VERSION=3.11.37 .
...
Successfully built 2d4fb119f01d
Successfully tagged myLabel:latest
```
The resulting image is currently around 218MB. This is not the minimal size as discussed in https://github.com/h2non/imaginary/issues/125, but I suppose it's not bad for a first attempt.
```sh
$ docker run --rm -it -p 9000:9000 h2non/imaginary:test -v
3.11.37
```
_In the automated workflow we'd obviously use something like `$(git describe --tags $(git rev-list --tags --max-count=1 4b825dc642cb6eb9a060e54bf8d69288fbee4904))`, but I've kept it short for brevity._

## Hacking on Imaginary
Just use the bimg base image, or build it yourself with the versions you'd like and use that as a base or stage. See, once again, the bimg PR: https://github.com/h2non/bimg/pull/273.

Once you've got the base, just mount a local path and happy hackin'
```sh
$ docker run --rm -it -v "local/path/to/imaginary:/go/src/github/h2non/imaginary" bimgBaseImage:tag
root@d5f8c55eaec3:/# cd /go/src/github.com/h2non/imaginary
root@d5f8c55eaec3:/go/src/github.com/h2non/imaginary# go test -test.race ./...
ok  	github.com/h2non/imaginary	2.446s
```

# Details
See the bimg PR: https://github.com/h2non/bimg/pull/273, most applies here as well.