### PR TITLE
Set go build ldflags to reduce binary size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN go get -u github.com/golang/dep/cmd/dep
 COPY . $GOPATH/src/github.com/h2non/imaginary
 
 # Compile imaginary
-RUN go build -o bin/imaginary github.com/h2non/imaginary
+RUN go build -ldflags "-s -w" -o bin/imaginary github.com/h2non/imaginary
 
 FROM ubuntu:16.04
 


### PR DESCRIPTION
7.97 Mb previously vs 6.02 Mb now

Here is [the explanation](https://golang.org/cmd/link/):

> -s
> 	Omit the symbol table and debug information.
> -w
> 	Omit the DWARF symbol table.