### PR TITLE
Adding parameter feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 go:
   - "1.11.x"
   - "1.10.x"
-  - "1.9.x"
   - "tip"
 
 env:
@@ -25,7 +24,6 @@ matrix:
     - env: LIBVIPS=8.2
     - env: LIBVIPS=8.3
     - env: LIBVIPS=master
-    - go: 1.9.x
 
 cache: apt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - env: LIBVIPS=8.2
     - env: LIBVIPS=8.3
     - env: LIBVIPS=master
-    - go: 1.8.x
+    - go: 1.9.x
 
 cache: apt
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To get started, take a look the [installation](#installation) steps, [usage](#co
 
 - [libvips](https://github.com/jcupitt/libvips) 8.3+ (8.5+ recommended)
 - C compatible compiler such as gcc 4.6+ or clang 3.0+
-- Go 1.6+
+- Go 1.10+
 
 ## Installation
 

--- a/controllers.go
+++ b/controllers.go
@@ -93,7 +93,12 @@ func imageHandler(w http.ResponseWriter, r *http.Request, buf []byte, Operation 
 		return
 	}
 
-	opts := readParams(r.URL.Query())
+	opts, err := buildParamsFromQuery(r.URL.Query())
+	if err != nil {
+		ErrorReply(r, w, NewError("Error while processing parameters, "+err.Error(), BadRequest), o)
+		return
+	}
+
 	vary := ""
 	if opts.Type == "auto" {
 		opts.Type = determineAcceptMimeType(r.Header.Get("Accept"))

--- a/image.go
+++ b/image.go
@@ -348,7 +348,11 @@ func Pipeline(buf []byte, o ImageOptions) (Image, error) {
 		}
 
 		// Parse and construct operation options
-		operation.ImageOptions = readMapParams(operation.Params)
+		var err error
+		operation.ImageOptions, err = buildParamsFromOperation(operation)
+		if err != nil {
+			return Image{}, err
+		}
 
 		// Mutate list by value
 		o.Operations[i] = operation

--- a/params.go
+++ b/params.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"math"
 	"net/url"
 	"strconv"
@@ -10,165 +12,379 @@ import (
 	"gopkg.in/h2non/bimg.v1"
 )
 
-var allowedParams = map[string]string{
-	"width":       "int",
-	"height":      "int",
-	"quality":     "int",
-	"top":         "int",
-	"left":        "int",
-	"areawidth":   "int",
-	"areaheight":  "int",
-	"compression": "int",
-	"rotate":      "int",
-	"margin":      "int",
-	"factor":      "int",
-	"dpi":         "int",
-	"textwidth":   "int",
-	"opacity":     "float",
-	"flip":        "bool",
-	"flop":        "bool",
-	"nocrop":      "bool",
-	"noprofile":   "bool",
-	"norotation":  "bool",
-	"noreplicate": "bool",
-	"force":       "bool",
-	"embed":       "bool",
-	"stripmeta":   "bool",
-	"text":        "string",
-	"image":       "string",
-	"font":        "string",
-	"type":        "string",
-	"color":       "color",
-	"colorspace":  "colorspace",
-	"gravity":     "gravity",
-	"background":  "color",
-	"extend":      "extend",
-	"sigma":       "float",
-	"minampl":     "float",
-	"operations":  "json",
+var ErrUnsupportedValue = errors.New("unsupported value")
+
+// Coercion is the type that type coerces a parameter and defines the appropriate field on ImageOptions
+type Coercion func(*ImageOptions, interface{}) error
+
+var paramTypeCoercions = map[string]Coercion{
+	"width":       coerceWidth,
+	"height":      coerceHeight,
+	"quality":     coerceQuality,
+	"top":         coerceTop,
+	"left":        coerceLeft,
+	"areawidth":   coerceAreaWidth,
+	"areaheight":  coerceAreaHeight,
+	"compression": coerceCompression,
+	"rotate":      coerceRotate,
+	"margin":      coerceMargin,
+	"factor":      coerceFactor,
+	"dpi":         coerceDPI,
+	"textwidth":   coerceTextWidth,
+	"opacity":     coerceOpacity,
+	"flip":        coerceFlip,
+	"flop":        coerceFlop,
+	"nocrop":      coerceNoCrop,
+	"noprofile":   coerceNoProfile,
+	"norotation":  coerceNoRotation,
+	"noreplicate": coerceNoReplicate,
+	"force":       coerceForce,
+	"embed":       coerceEmbed,
+	"stripmeta":   coerceStripMeta,
+	"text":        coerceText,
+	"image":       coerceImage,
+	"font":        coerceFont,
+	"type":        coerceImageType,
+	"color":       coerceColor,
+	"colorspace":  coerceColorSpace,
+	"gravity":     coerceGravity,
+	"background":  coerceBackground,
+	"extend":      coerceExtend,
+	"sigma":       coerceSigma,
+	"minampl":     coerceMinAmpl,
+	"operations":  coerceOperations,
 }
 
-func readParams(query url.Values) ImageOptions {
-	params := make(map[string]interface{})
-
-	for key, kind := range allowedParams {
-		param := query.Get(key)
-		params[key] = parseParam(param, kind)
+func coerceTypeInt(param interface{}) (int, error) {
+	if v, ok := param.(int); ok {
+		return v, nil
 	}
 
-	return mapImageParams(params)
+	if v, ok := param.(float64); ok {
+		return int(v), nil
+	}
+
+	if v, ok := param.(string); ok {
+		return parseInt(v)
+	}
+
+	return 0, ErrUnsupportedValue
 }
 
-func readMapParams(options map[string]interface{}) ImageOptions {
-	params := make(map[string]interface{})
+func coerceTypeFloat(param interface{}) (float64, error) {
+	if v, ok := param.(float64); ok {
+		return v, nil
+	}
 
-	for key, kind := range allowedParams {
-		value, ok := options[key]
+	if v, ok := param.(int); ok {
+		return float64(v), nil
+	}
+
+	if v, ok := param.(string); ok {
+		result, err := parseFloat(v)
+		if err != nil {
+			return 0, ErrUnsupportedValue
+		}
+
+		return result, nil
+	}
+
+	return 0, ErrUnsupportedValue
+}
+
+func coerceTypeBool(param interface{}) (bool, error) {
+	if v, ok := param.(bool); ok {
+		return v, nil
+	}
+
+	if v, ok := param.(string); ok {
+		result, err := parseBool(v)
+		if err != nil {
+			return false, ErrUnsupportedValue
+		}
+
+		return result, nil
+	}
+
+	return false, ErrUnsupportedValue
+}
+
+func coerceTypeString(param interface{}) (string, error) {
+	if v, ok := param.(string); ok {
+		return v, nil
+	}
+
+	return "", ErrUnsupportedValue
+}
+
+func coerceHeight(io *ImageOptions, param interface{}) (err error) {
+	io.Height, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceWidth(io *ImageOptions, param interface{}) (err error) {
+	io.Width, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceQuality(io *ImageOptions, param interface{}) (err error) {
+	io.Quality, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceTop(io *ImageOptions, param interface{}) (err error) {
+	io.Top, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceLeft(io *ImageOptions, param interface{}) (err error) {
+	io.Left, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceAreaWidth(io *ImageOptions, param interface{}) (err error) {
+	io.AreaWidth, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceAreaHeight(io *ImageOptions, param interface{}) (err error) {
+	io.AreaHeight, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceCompression(io *ImageOptions, param interface{}) (err error) {
+	io.Compression, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceRotate(io *ImageOptions, param interface{}) (err error) {
+	io.Rotate, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceMargin(io *ImageOptions, param interface{}) (err error) {
+	io.Margin, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceFactor(io *ImageOptions, param interface{}) (err error) {
+	io.Factor, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceDPI(io *ImageOptions, param interface{}) (err error) {
+	io.DPI, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceTextWidth(io *ImageOptions, param interface{}) (err error) {
+	io.TextWidth, err = coerceTypeInt(param)
+	return err
+}
+
+func coerceOpacity(io *ImageOptions, param interface{}) (err error) {
+	v, err := coerceTypeFloat(param)
+	io.Opacity = float32(v)
+	return err
+}
+
+func coerceFlip(io *ImageOptions, param interface{}) (err error) {
+	io.Flip, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceFlop(io *ImageOptions, param interface{}) (err error) {
+	io.Flop, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceNoCrop(io *ImageOptions, param interface{}) (err error) {
+	io.NoCrop, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceNoProfile(io *ImageOptions, param interface{}) (err error) {
+	io.NoProfile, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceNoRotation(io *ImageOptions, param interface{}) (err error) {
+	io.NoRotation, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceNoReplicate(io *ImageOptions, param interface{}) (err error) {
+	io.NoReplicate, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceForce(io *ImageOptions, param interface{}) (err error) {
+	io.Force, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceEmbed(io *ImageOptions, param interface{}) (err error) {
+	io.Embed, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceStripMeta(io *ImageOptions, param interface{}) (err error) {
+	io.StripMetadata, err = coerceTypeBool(param)
+	return err
+}
+
+func coerceText(io *ImageOptions, param interface{}) (err error) {
+	io.Text, err = coerceTypeString(param)
+	return err
+}
+
+func coerceImage(io *ImageOptions, param interface{}) (err error) {
+	io.Image, err = coerceTypeString(param)
+	return err
+}
+
+func coerceFont(io *ImageOptions, param interface{}) (err error) {
+	io.Font, err = coerceTypeString(param)
+	return err
+}
+
+func coerceImageType(io *ImageOptions, param interface{}) (err error) {
+	io.Type, err = coerceTypeString(param)
+	return err
+}
+
+func coerceColor(io *ImageOptions, param interface{}) error {
+	if v, ok := param.(string); ok {
+		io.Color = parseColor(v)
+		return nil
+	}
+
+	return ErrUnsupportedValue
+}
+
+func coerceColorSpace(io *ImageOptions, param interface{}) error {
+	if v, ok := param.(string); ok {
+		io.Colorspace = parseColorspace(v)
+		return nil
+	}
+
+	return ErrUnsupportedValue
+}
+
+func coerceGravity(io *ImageOptions, param interface{}) error {
+	if v, ok := param.(string); ok {
+		io.Gravity = parseGravity(v)
+		return nil
+	}
+
+	return ErrUnsupportedValue
+}
+
+func coerceBackground(io *ImageOptions, param interface{}) error {
+	if v, ok := param.(string); ok {
+		io.Background = parseColor(v)
+		return nil
+	}
+
+	return ErrUnsupportedValue
+}
+
+func coerceExtend(io *ImageOptions, param interface{}) error {
+	if v, ok := param.(string); ok {
+		io.Extend = parseExtendMode(v)
+		return nil
+	}
+
+	return ErrUnsupportedValue
+}
+
+func coerceSigma(io *ImageOptions, param interface{}) (err error) {
+	io.Sigma, err = coerceTypeFloat(param)
+	return err
+}
+
+func coerceMinAmpl(io *ImageOptions, param interface{}) (err error) {
+	io.MinAmpl, err = coerceTypeFloat(param)
+	return err
+}
+
+func coerceOperations(io *ImageOptions, param interface{}) (err error) {
+	if v, ok := param.(string); ok {
+		ops, err := parseJSONOperations(v)
+		if err == nil {
+			io.Operations = ops
+		}
+
+		return err
+	}
+
+	return ErrUnsupportedValue
+}
+
+func buildParamsFromOperation(op PipelineOperation) (ImageOptions, error) {
+
+	var options ImageOptions
+
+	for key, value := range op.Params {
+		fn, ok := paramTypeCoercions[key]
 		if !ok {
-			// Force type defaults
-			params[key] = parseParam("", kind)
 			continue
 		}
 
-		// Parse non JSON primitive types that would be represented as string types
-		if kind == "color" || kind == "colorspace" || kind == "gravity" || kind == "extend" {
-			if v, ok := value.(string); ok {
-				params[key] = parseParam(v, kind)
-			}
-		} else if kind == "int" {
-			if v, ok := value.(float64); ok {
-				params[key] = int(v)
-			}
-			if v, ok := value.(int); ok {
-				params[key] = v
-			}
-		} else {
-			params[key] = value
+		err := fn(&options, value)
+		if err != nil {
+			return ImageOptions{}, fmt.Errorf(`error while processing parameter "%s" with value %q, error: %s`, key, value, err)
 		}
 	}
 
-	return mapImageParams(params)
+	return options, nil
 }
 
-func parseParam(param, kind string) interface{} {
-	if kind == "int" {
-		return parseInt(param)
+// buildParamsFromQuery builds the ImageOptions type from untyped parameters
+func buildParamsFromQuery(query url.Values) (ImageOptions, error) {
+	var options ImageOptions
+
+	// Extract only known parameters
+	for key := range query {
+		fn, ok := paramTypeCoercions[key]
+		if !ok {
+			continue
+		}
+
+		value := query.Get(key)
+		err := fn(&options, value)
+		if err != nil {
+			return ImageOptions{}, fmt.Errorf(`error while processing parameter "%s" with value %q, error: %s`, key, value, err)
+		}
 	}
-	if kind == "float" {
-		return parseFloat(param)
-	}
-	if kind == "color" {
-		return parseColor(param)
-	}
-	if kind == "colorspace" {
-		return parseColorspace(param)
-	}
-	if kind == "gravity" {
-		return parseGravity(param)
-	}
-	if kind == "bool" {
-		return parseBool(param)
-	}
-	if kind == "extend" {
-		return parseExtendMode(param)
-	}
-	if kind == "json" {
-		return parseJSONOperations(param)
-	}
-	return param
+
+	return options, nil
 }
 
-func mapImageParams(params map[string]interface{}) ImageOptions {
-	return ImageOptions{
-		Width:         params["width"].(int),
-		Height:        params["height"].(int),
-		Top:           params["top"].(int),
-		Left:          params["left"].(int),
-		AreaWidth:     params["areawidth"].(int),
-		AreaHeight:    params["areaheight"].(int),
-		DPI:           params["dpi"].(int),
-		Quality:       params["quality"].(int),
-		TextWidth:     params["textwidth"].(int),
-		Compression:   params["compression"].(int),
-		Rotate:        params["rotate"].(int),
-		Factor:        params["factor"].(int),
-		Color:         params["color"].([]uint8),
-		Text:          params["text"].(string),
-		Image:         params["image"].(string),
-		Font:          params["font"].(string),
-		Type:          params["type"].(string),
-		Flip:          params["flip"].(bool),
-		Flop:          params["flop"].(bool),
-		Embed:         params["embed"].(bool),
-		NoCrop:        params["nocrop"].(bool),
-		Force:         params["force"].(bool),
-		NoReplicate:   params["noreplicate"].(bool),
-		NoRotation:    params["norotation"].(bool),
-		NoProfile:     params["noprofile"].(bool),
-		StripMetadata: params["stripmeta"].(bool),
-		Opacity:       float32(params["opacity"].(float64)),
-		Extend:        params["extend"].(bimg.Extend),
-		Gravity:       params["gravity"].(bimg.Gravity),
-		Colorspace:    params["colorspace"].(bimg.Interpretation),
-		Background:    params["background"].([]uint8),
-		Sigma:         params["sigma"].(float64),
-		MinAmpl:       params["minampl"].(float64),
-		Operations:    params["operations"].(PipelineOperations),
+func parseBool(val string) (bool, error) {
+	if val == "" {
+		return false, nil
 	}
+
+	return strconv.ParseBool(val)
 }
 
-func parseBool(val string) bool {
-	value, _ := strconv.ParseBool(val)
-	return value
+func parseInt(param string) (int, error) {
+	if param == "" {
+		return 0, nil
+	}
+
+	f, err := parseFloat(param)
+	return int(math.Floor(f + 0.5)), err
 }
 
-func parseInt(param string) int {
-	return int(math.Floor(parseFloat(param) + 0.5))
-}
+func parseFloat(param string) (float64, error) {
+	if param == "" {
+		return 0.0, nil
+	}
 
-func parseFloat(param string) float64 {
-	val, _ := strconv.ParseFloat(param, 64)
-	return math.Abs(val)
+	val, err := strconv.ParseFloat(param, 64)
+	return math.Abs(val), err
 }
 
 func parseColorspace(val string) bimg.Interpretation {
@@ -180,7 +396,7 @@ func parseColorspace(val string) bimg.Interpretation {
 
 func parseColor(val string) []uint8 {
 	const max float64 = 255
-	buf := []uint8{}
+	var buf []uint8
 	if val != "" {
 		for _, num := range strings.Split(val, ",") {
 			n, _ := strconv.ParseUint(strings.Trim(num, " "), 10, 8)
@@ -190,10 +406,19 @@ func parseColor(val string) []uint8 {
 	return buf
 }
 
-func parseJSONOperations(data string) PipelineOperations {
-	operations := PipelineOperations{}
-	json.Unmarshal([]byte(data), &operations)
-	return operations
+func parseJSONOperations(data string) (PipelineOperations, error) {
+	var operations PipelineOperations
+
+	// Fewer than 2 characters cannot be valid JSON. We assume empty operation.
+	if len(data) < 2 {
+		return operations, nil
+	}
+
+	d := json.NewDecoder(strings.NewReader(data))
+	d.DisallowUnknownFields()
+
+	err := d.Decode(&operations)
+	return operations, err
 }
 
 func parseExtendMode(val string) bimg.Extend {

--- a/params_test.go
+++ b/params_test.go
@@ -252,7 +252,6 @@ func TestBuildParamsFromOperation(t *testing.T) {
 			"stripmeta":  false,
 			"type":       "jpeg",
 			"background": "255,12,3",
-			//"operations": `[{"operation":"resize","params":{"quality":70,"noprofile":true,"stripmeta":true,"nocrop":true,"width":865}}]`,
 		},
 	}
 
@@ -261,16 +260,20 @@ func TestBuildParamsFromOperation(t *testing.T) {
 		t.Errorf("Expected this to work! %s", err)
 	}
 
-	if options.Width != 200 {
-		t.Errorf("Expected the Width to be coerced with the correct value of %d", 200)
+	if input := op.Params["width"].(int); options.Width != 200 {
+		t.Errorf("Expected the Width to be coerced with the correct value of %d", input)
 	}
 
-	if int(options.Opacity*10) != 22 {
-		t.Errorf("Expected the Opacity to be coerced with the correct value of %f", 2.2)
+	if input := op.Params["opacity"].(float64); math.Abs(input-float64(options.Opacity)) > epsilon {
+		t.Errorf("Expected the Opacity to be coerced with the correct value of %f", input)
 	}
 
 	if options.Force != true || options.StripMetadata != false {
 		t.Errorf("Expected boolean parameters to result in their respective value's\n%+v", options)
+	}
+
+	if input := op.Params["background"].(string); options.Background[0] != 255 {
+		t.Errorf("Expected color parameter to be coerced with the correct value of %s", input)
 	}
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"math"
 	"net/url"
 	"testing"
 
 	"gopkg.in/h2non/bimg.v1"
 )
 
-const fixture = "fixtures/large.jpg"
+const epsilon = 0.0001
 
 func TestReadParams(t *testing.T) {
 	q := url.Values{}
@@ -18,7 +19,10 @@ func TestReadParams(t *testing.T) {
 	q.Add("text", "hello")
 	q.Add("background", "255,10,20")
 
-	params := readParams(q)
+	params, err := buildParamsFromQuery(q)
+	if err != nil {
+		t.Errorf("Failed reading params, %s", err)
+	}
 
 	assert := params.Width == 100 &&
 		params.Height == 80 &&
@@ -47,7 +51,7 @@ func TestParseParam(t *testing.T) {
 	}
 
 	for _, test := range intCases {
-		val := parseParam(test.value, "int")
+		val, _ := parseInt(test.value)
 		if val != test.expected {
 			t.Errorf("Invalid param: %s != %d", test.value, test.expected)
 		}
@@ -64,7 +68,7 @@ func TestParseParam(t *testing.T) {
 	}
 
 	for _, test := range floatCases {
-		val := parseParam(test.value, "float")
+		val, _ := parseFloat(test.value)
 		if val != test.expected {
 			t.Errorf("Invalid param: %#v != %#v", val, test.expected)
 		}
@@ -86,7 +90,7 @@ func TestParseParam(t *testing.T) {
 	}
 
 	for _, test := range boolCases {
-		val := parseParam(test.value, "bool")
+		val, _ := parseBool(test.value)
 		if val != test.expected {
 			t.Errorf("Invalid param: %#v != %#v", val, test.expected)
 		}
@@ -159,7 +163,7 @@ func TestGravity(t *testing.T) {
 	}
 
 	for _, td := range cases {
-		io := readParams(url.Values{"gravity": []string{td.gravityValue}})
+		io, _ := buildParamsFromQuery(url.Values{"gravity": []string{td.gravityValue}})
 		if (io.Gravity == bimg.GravitySmart) != td.smartCropValue {
 			t.Errorf("Expected %t to be %t, test data: %+v", io.Gravity == bimg.GravitySmart, td.smartCropValue, td)
 		}
@@ -192,7 +196,11 @@ func TestReadMapParams(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		opts := readMapParams(test.params)
+		opts, err := buildParamsFromOperation(PipelineOperation{Params: test.params})
+		if err != nil {
+			t.Errorf("Error reading parameters %s", err)
+			t.FailNow()
+		}
 		if opts.Width != test.expected.Width {
 			t.Errorf("Invalid width: %d != %d", opts.Width, test.expected.Width)
 		}
@@ -212,4 +220,182 @@ func TestReadMapParams(t *testing.T) {
 			t.Errorf("Invalid color: %#v != %#v", opts.Color, test.expected.Color)
 		}
 	}
+}
+
+func TestParseFunctions(t *testing.T) {
+	t.Run("parseBool", func(t *testing.T) {
+		if r, err := parseBool("true"); r != true {
+			t.Errorf("Expected string true to result a native type true %s", err)
+		}
+
+		if r, err := parseBool("false"); r != false {
+			t.Errorf("Expected string false to result a native type false %s", err)
+		}
+
+		// A special case that we support
+		if _, err := parseBool(""); err != nil {
+			t.Errorf("Expected blank values to default to false, it didn't! %s", err)
+		}
+
+		if r, err := parseBool("foo"); err == nil {
+			t.Errorf("Expected malformed values to result in an error, it didn't! %+v", r)
+		}
+	})
+}
+
+func TestBuildParamsFromOperation(t *testing.T) {
+	op := PipelineOperation{
+		Params: map[string]interface{}{
+			"width":      200,
+			"opacity":    2.2,
+			"force":      true,
+			"stripmeta":  false,
+			"type":       "jpeg",
+			"background": "255,12,3",
+			//"operations": `[{"operation":"resize","params":{"quality":70,"noprofile":true,"stripmeta":true,"nocrop":true,"width":865}}]`,
+		},
+	}
+
+	options, err := buildParamsFromOperation(op)
+	if err != nil {
+		t.Errorf("Expected this to work! %s", err)
+	}
+
+	if options.Width != 200 {
+		t.Errorf("Expected the Width to be coerced with the correct value of %d", 200)
+	}
+
+	if int(options.Opacity*10) != 22 {
+		t.Errorf("Expected the Opacity to be coerced with the correct value of %f", 2.2)
+	}
+
+	if options.Force != true || options.StripMetadata != false {
+		t.Errorf("Expected boolean parameters to result in their respective value's\n%+v", options)
+	}
+}
+
+func TestCoerceTypeFns(t *testing.T) {
+	t.Run("coerceTypeInt", func(t *testing.T) {
+		cases := []struct {
+			Input  interface{}
+			Expect int
+			Err    error
+		}{
+			{Input: "200", Expect: 200},
+			{Input: int(200), Expect: 200},
+			{Input: float64(200), Expect: 200},
+			{Input: false, Expect: 0, Err: ErrUnsupportedValue},
+		}
+
+		for _, tc := range cases {
+
+			result, err := coerceTypeInt(tc.Input)
+			if err != nil && tc.Err == nil {
+				t.Errorf("Did not expect error %s\n%+v", err, tc)
+				t.FailNow()
+			}
+
+			if tc.Err != nil && tc.Err != err {
+				t.Errorf("Expected an error to be thrown\nExpected: %s\nReceived: %s", tc.Err, err)
+				t.FailNow()
+			}
+
+			if tc.Err == nil && result != tc.Expect {
+				t.Errorf("Expected proper coercion %s\n%+v\n%+v", err, result, tc)
+			}
+		}
+	})
+
+	t.Run("coerceTypeFloat", func(t *testing.T) {
+		cases := []struct {
+			Input  interface{}
+			Expect float64
+			Err    error
+		}{
+			{Input: "200", Expect: 200},
+			{Input: int(200), Expect: 200},
+			{Input: float64(200), Expect: 200},
+			{Input: false, Expect: 0, Err: ErrUnsupportedValue},
+		}
+
+		for _, tc := range cases {
+
+			result, err := coerceTypeFloat(tc.Input)
+			if err != nil && tc.Err == nil {
+				t.Errorf("Did not expect error %s\n%+v", err, tc)
+				t.FailNow()
+			}
+
+			if tc.Err != nil && tc.Err != err {
+				t.Errorf("Expected an error to be thrown\nExpected: %s\nReceived: %s", tc.Err, err)
+				t.FailNow()
+			}
+
+			if tc.Err == nil && math.Abs(result-tc.Expect) > epsilon {
+				t.Errorf("Expected proper coercion %s\n%+v\n%+v", err, result, tc)
+			}
+		}
+	})
+
+	t.Run("coerceTypeBool", func(t *testing.T) {
+		cases := []struct {
+			Input  interface{}
+			Expect bool
+			Err    error
+		}{
+			{Input: "true", Expect: true},
+			{Input: true, Expect: true},
+			{Input: "1", Expect: true},
+			{Input: "bubblegum", Expect: false, Err: ErrUnsupportedValue},
+		}
+
+		for _, tc := range cases {
+
+			result, err := coerceTypeBool(tc.Input)
+			if err != nil && tc.Err == nil {
+				t.Errorf("Did not expect error %s\n%+v", err, tc)
+				t.FailNow()
+			}
+
+			if tc.Err != nil && tc.Err != err {
+				t.Errorf("Expected an error to be thrown\nExpected: %s\nReceived: %s", tc.Err, err)
+				t.FailNow()
+			}
+
+			if tc.Err == nil && result != tc.Expect {
+				t.Errorf("Expected proper coercion %s\n%+v\n%+v", err, result, tc)
+			}
+		}
+	})
+
+	t.Run("coerceTypeString", func(t *testing.T) {
+		cases := []struct {
+			Input  interface{}
+			Expect string
+			Err    error
+		}{
+			{Input: "true", Expect: "true"},
+			{Input: false, Err: ErrUnsupportedValue},
+			{Input: 0.0, Err: ErrUnsupportedValue},
+			{Input: 0, Err: ErrUnsupportedValue},
+		}
+
+		for _, tc := range cases {
+
+			result, err := coerceTypeString(tc.Input)
+			if err != nil && tc.Err == nil {
+				t.Errorf("Did not expect error %s\n%+v", err, tc)
+				t.FailNow()
+			}
+
+			if tc.Err != nil && tc.Err != err {
+				t.Errorf("Expected an error to be thrown\nExpected: %s\nReceived: %s", tc.Err, err)
+				t.FailNow()
+			}
+
+			if tc.Err == nil && result != tc.Expect {
+				t.Errorf("Expected proper coercion %s\n%+v\n%+v", err, result, tc)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Warning. Here be (albeit tiny) dragons.

I've spent a quite a while trying to simplify the parameter handling. It was rather complicated to grasp since there were two pretty different cases: The Pipeline and the HTTP parameter handling.

I've, eventually, came up with a pretty radical rewrite of the parameter handling. There is quite a bit of boilerplate, but (imho) it's now much simpler to deal with parameters and much less passing around of `interface{}` types.

There aren't breaking API changes. In some cases it wasn't allowed to pass in a string where a number was expected (e.g.: `{"width": 200}` versus `{"width": "200"}`). In the new situation that is allowed. While I'm not necessarily a fan of allowing strings where numbers are "correct", this is a side-effect of how the `parse<T>()` functions are implemented. It's more generic (HTTP parameter versus JSON types) and hopefully easier to understand.

There is also slightly more information when the user does pass in a wrong parameter, e.g.:
```sh
curl -sv "http://localhost:9000/pipeline?url=https://pbs.twimg.com/media/DwX-vRdUYAACZ0x.jpg&operations=%5B%7B%22operation%22%3A%22resize%22%2C%22params%22%3A%7B%22quality%22%3A70%2C%22noprofile%22%3Atrue%2C%22stripmeta%22%3Atrue%2C%22nocrop%22%3A%22foo%22%2C%22width%22%3A865%7D%7D%5D"
```

```json
{
  "message": "Error while processing the image: error while processing parameter \"nocrop\" with value \"foo\", error: unsupported value",
  "code": 1
}
```

Inspired by issues https://github.com/h2non/imaginary/issues/236 and https://github.com/h2non/imaginary/issues/233

## Breaking Pre-Go1.10 compatibility
I've added the new (since Go 1.10) flag [`DisallowUnknownFields()`](https://golang.org/pkg/encoding/json/#Decoder.DisallowUnknownFields) on the JSON decoder. This causes Imaginary to be >= Go 1.10. Personally I think it's fine, but if this is a problem I can drop the flag and this way we'll support older Go versions.