### PR TITLE
docker: switch to debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,34 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM ubuntu:16.04 as builder
+FROM golang:1.11.4 as builder
 MAINTAINER tomas@aparicio.me
 
-ENV LIBVIPS_VERSION 8.7.0
+ENV LIBVIPS_VERSION 8.7.4
 
 # Installs libvips + required libraries
 RUN \
-
-  # Install dependencies
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ca-certificates \
   automake build-essential curl \
-  gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg-turbo8-dev libpng12-dev \
+  gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg62-turbo-dev libpng-dev \
   libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev \
   swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev \
   libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev && \
-
-  # Build libvips
   cd /tmp && \
   curl -OL https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.gz && \
-  tar zvxf vips-${LIBVIPS_VERSION}.tar.gz && \
+  tar zxf vips-${LIBVIPS_VERSION}.tar.gz && \
   cd /tmp/vips-${LIBVIPS_VERSION} && \
   ./configure --enable-debug=no --without-python $1 && \
   make && \
   make install && \
   ldconfig && \
-
-  # Clean up
   apt-get remove -y curl automake build-essential && \
   apt-get autoremove -y && \
   apt-get autoclean && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Server port to listen
-ENV PORT 9000
-
-# Go version to use
-ENV GOLANG_VERSION 1.11.2
-
-# gcc for cgo
-RUN apt-get update && apt-get install -y \
-    gcc curl git libc6-dev make \
-    --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/*
-
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d
-
-RUN curl -fsSL --insecure "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
-  && echo "$GOLANG_DOWNLOAD_SHA256 golang.tar.gz" | sha256sum -c - \
-  && tar -C /usr/local -xzf golang.tar.gz \
-  && rm golang.tar.gz
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
 # Fetch the latest version of the package
@@ -71,17 +41,15 @@ COPY . $GOPATH/src/github.com/h2non/imaginary
 # Compile imaginary
 RUN go build -o bin/imaginary github.com/h2non/imaginary
 
-FROM ubuntu:16.04
+FROM debian:stretch-slim
 
 RUN \
-  # Install runtime dependencies
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-  libglib2.0-0 libjpeg-turbo8 libpng12-0 libopenexr22 \
-  libwebp5 libtiff5 libgif7 libexif12 libxml2 libpoppler-glib8 \
-  libmagickwand-6.q16-2 libpango1.0-0 libmatio2 libopenslide0 \
-  libgsf-1-114 fftw3 liborc-0.4 librsvg2-2 libcfitsio2 && \
-  # Clean up
+  libglib2.0-0 libjpeg62-turbo libpng16-16 libopenexr22 \
+  libwebp6 libwebpmux2 libtiff5 libgif7 libexif12 libxml2 libpoppler-glib8 \
+  libmagickwand-6.q16-3 libpango1.0-0 libmatio4 libopenslide0 \
+  libgsf-1-114 fftw3 liborc-0.4 librsvg2-2 libcfitsio5 && \
   apt-get autoremove -y && \
   apt-get autoclean && \
   apt-get clean && \


### PR DESCRIPTION
Switch from ubuntu 16 to debian stretch as baseline. This introducesa few improvements:

1. go upstream already uses stretch; we can avoid compiling go
2. slightly newer dependencies (libvips performance improvements)
3. 17MB size reduction:
```
h2non/imaginary    latest    a1c7815c3fa8   24 hours ago     218MB
h2non/imaginary    stretch   58f546f6569c   7 minutes ago    201MB
```

Note: docker warned about empty lines/comments in `RUN` args, hence removed:
```console
[WARNING]: Empty continuation line found in:
    RUN   apt-get update &&   DEBIAN_FRONTEND=noninteractive apt-get install -y   ca-certificates   automake build-essential curl   gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg-turbo8-dev libpng12-dev   libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev   swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev   libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev &&   cd /tmp &&   curl -OL https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.gz &&   tar zvxf vips-${LIBVIPS_VERSION}.tar.gz &&   cd /tmp/vips-${LIBVIPS_VERSION} &&   ./configure --enable-debug=no --without-python $1 &&   make &&   make install &&   ldconfig &&   apt-get remove -y curl automake build-essential &&   apt-get autoremove -y &&   apt-get autoclean &&   apt-get clean &&   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
[WARNING]: Empty continuation lines will become errors in a future release
```