### PR TITLE
Isolated the calculation added a test and added Rounding

### DIFF
--- a/image.go
+++ b/image.go
@@ -142,7 +142,7 @@ func Fit(buf []byte, o ImageOptions) (Image, error) {
 		fitHeight = &o.Width
 	}
 
-	*fitHeight, *fitWidth = calculateDestinationFitDimension(originWidth, originHeight, *fitWidth, *fitHeight)
+	*fitWidth, *fitHeight = calculateDestinationFitDimension(originWidth, originHeight, *fitWidth, *fitHeight)
 
 	opts := BimgOptions(o)
 	opts.Embed = true

--- a/image_test.go
+++ b/image_test.go
@@ -71,3 +71,39 @@ func TestImagePipelineOperations(t *testing.T) {
 		t.Errorf("Invalid image size, expected: %dx%d", width, height)
 	}
 }
+
+func TestCalculateDestinationFitDimension(t *testing.T) {
+	cases := []struct {
+		// Image
+		imageWidth  int
+		imageHeight int
+
+		// User parameter
+		optionWidth  int
+		optionHeight int
+
+		// Expect
+		fitWidth  int
+		fitHeight int
+	}{
+
+		// Leading Width
+		{1280, 1000, 710, 9999, 710, 555},
+		{1279, 1000, 710, 9999, 710, 555},
+
+		// Leading height
+		{1299, 2000, 710, 999, 649, 999},
+		{1500, 2000, 710, 999, 710, 947},
+	}
+
+	for _, tc := range cases {
+		fitWidth, fitHeight := calculateDestinationFitDimension(tc.imageWidth, tc.imageHeight, tc.optionWidth, tc.optionHeight)
+		if fitWidth != tc.fitWidth || fitHeight != tc.fitHeight {
+			t.Errorf(
+				"Fit dimensions calculation failure\nExpected : %d/%d (width/height)\nActual   : %d/%d (width/height)\n%+v",
+				tc.fitWidth, tc.fitHeight, fitWidth, fitHeight, tc,
+			)
+		}
+	}
+
+}

--- a/image_test.go
+++ b/image_test.go
@@ -90,6 +90,8 @@ func TestCalculateDestinationFitDimension(t *testing.T) {
 		// Leading Width
 		{1280, 1000, 710, 9999, 710, 555},
 		{1279, 1000, 710, 9999, 710, 555},
+		{900, 500, 312, 312, 312, 173}, // rounding down
+		{900, 500, 313, 313, 313, 174}, // rounding up
 
 		// Leading height
 		{1299, 2000, 710, 999, 649, 999},

--- a/image_test.go
+++ b/image_test.go
@@ -32,8 +32,8 @@ func TestImageFit(t *testing.T) {
 	if img.Mime != "image/jpeg" {
 		t.Error("Invalid image MIME type")
 	}
-	// 550x740 -> 222x300
-	if assertSize(img.Body, 222, 300) != nil {
+	// 550x740 -> 222.9x300
+	if assertSize(img.Body, 223, 300) != nil {
 		t.Errorf("Invalid image size, expected: %dx%d", opts.Width, opts.Height)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -253,7 +253,14 @@ func TestFit(t *testing.T) {
 		t.Fatalf("Empty response body")
 	}
 
-	err = assertSize(image, 300, 168)
+	original, _ := ioutil.ReadAll(buf)
+	err = assertSize(original, 1920, 1080)
+	if err != nil {
+		t.Errorf("Reference image expecations weren't met")
+	}
+
+	// The reference image has a ratio of 1.778, this should produce a height of 168.75
+	err = assertSize(image, 300, 169)
 	if err != nil {
 		t.Error(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -231,12 +232,20 @@ func TestTypeAuto(t *testing.T) {
 }
 
 func TestFit(t *testing.T) {
-	ts := testServer(controller(Fit))
+	var err error
+
 	buf := readFile("large.jpg")
+	original, _ := ioutil.ReadAll(buf)
+	err = assertSize(original, 1920, 1080)
+	if err != nil {
+		t.Errorf("Reference image expecations weren't met")
+	}
+
+	ts := testServer(controller(Fit))
 	url := ts.URL + "?width=300&height=300"
 	defer ts.Close()
 
-	res, err := http.Post(url, "image/jpeg", buf)
+	res, err := http.Post(url, "image/jpeg", bytes.NewReader(original))
 	if err != nil {
 		t.Fatal("Cannot perform the request")
 	}
@@ -251,12 +260,6 @@ func TestFit(t *testing.T) {
 	}
 	if len(image) == 0 {
 		t.Fatalf("Empty response body")
-	}
-
-	original, _ := ioutil.ReadAll(buf)
-	err = assertSize(original, 1920, 1080)
-	if err != nil {
-		t.Errorf("Reference image expecations weren't met")
 	}
 
 	// The reference image has a ratio of 1.778, this should produce a height of 168.75


### PR DESCRIPTION
This issue _partially_ offers a fix for https://github.com/h2non/imaginary/issues/238. However this PR doesn't remove the black line, which still needs fixing.

I'm not actually sure if this calculation is correct. Several authors have touched this part and no rounding happend in the previous calculations. This cautions me to be optimistic about it's correctness, although they now do seem "sensible".

I'd happily receive some feedback from anyone about the correctness of the math involved `¯\_(ツ)_/¯`