### PR TITLE
Checking if a parameter value was specified in the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Image measures are always in pixels, unless otherwise indicated.
 - **flip**        `bool`  - Transform the resultant image with flip operation. Default: `false`
 - **flop**        `bool`  - Transform the resultant image with flop operation. Default: `false`
 - **force**       `bool`  - Force image transformation size. Default: `false`
-- **nocrop**      `bool`  - Disable crop transformation enabled by default by some operations. Default: `false`
+- **nocrop**      `bool`  - Disable crop transformation. Defaults depend on the operation
 - **noreplicate** `bool`  - Disable text replication in watermark. Defaults to `false`
 - **norotation**  `bool`  - Disable auto rotation based on EXIF orientation. Defaults to `false`
 - **noprofile**   `bool`  - Disable adding ICC profile metadata. Defaults to `false`
@@ -686,6 +686,7 @@ Resize an image by width or height. Image aspect ratio is maintained
 - embed `bool`
 - force `bool`
 - rotate `int`
+- nocrop `bool` - Defaults to `true`
 - norotation `bool`
 - noprofile `bool`
 - stripmeta `bool`
@@ -713,6 +714,7 @@ Accepts: `image/*, multipart/form-data`. Content-Type: `image/*`
 - embed `bool`
 - force `bool`
 - rotate `int`
+- nocrop `bool` - Defaults to `false`
 - norotation `bool`
 - noprofile `bool`
 - stripmeta `bool`
@@ -772,6 +774,7 @@ Accepts: `image/*, multipart/form-data`. Content-Type: `image/*`
 - embed `bool`
 - force `bool`
 - rotate `int`
+- nocrop `bool` - Defaults to `true`
 - norotation `bool`
 - noprofile `bool`
 - stripmeta `bool`

--- a/image.go
+++ b/image.go
@@ -93,8 +93,8 @@ func Resize(buf []byte, o ImageOptions) (Image, error) {
 	opts := BimgOptions(o)
 	opts.Embed = true
 
-	if !o.NoCrop {
-		opts.Crop = true
+	if o.IsDefinedField.NoCrop {
+		opts.Crop = !o.NoCrop
 	}
 
 	return Process(buf, opts)
@@ -171,9 +171,8 @@ func Enlarge(buf []byte, o ImageOptions) (Image, error) {
 	opts := BimgOptions(o)
 	opts.Enlarge = true
 
-	if !o.NoCrop {
-		opts.Crop = true
-	}
+	// Since both width & height is required, we allow cropping by default.
+	opts.Crop = !o.NoCrop
 
 	return Process(buf, opts)
 }
@@ -259,8 +258,8 @@ func Zoom(buf []byte, o ImageOptions) (Image, error) {
 		opts.AreaWidth = o.AreaWidth
 		opts.AreaHeight = o.AreaHeight
 
-		if o.NoCrop == false {
-			opts.Crop = true
+		if o.IsDefinedField.NoCrop {
+			opts.Crop = !o.NoCrop
 		}
 	}
 

--- a/image_test.go
+++ b/image_test.go
@@ -6,19 +6,74 @@ import (
 )
 
 func TestImageResize(t *testing.T) {
-	opts := ImageOptions{Width: 300, Height: 300}
-	buf, _ := ioutil.ReadAll(readFile("imaginary.jpg"))
+	t.Run("Width and Height defined", func(t *testing.T) {
+		opts := ImageOptions{Width: 300, Height: 300}
+		buf, _ := ioutil.ReadAll(readFile("imaginary.jpg"))
 
-	img, err := Resize(buf, opts)
-	if err != nil {
-		t.Errorf("Cannot process image: %s", err)
-	}
-	if img.Mime != "image/jpeg" {
-		t.Error("Invalid image MIME type")
-	}
-	if assertSize(img.Body, opts.Width, opts.Height) != nil {
-		t.Errorf("Invalid image size, expected: %dx%d", opts.Width, opts.Height)
-	}
+		img, err := Resize(buf, opts)
+		if err != nil {
+			t.Errorf("Cannot process image: %s", err)
+		}
+		if img.Mime != "image/jpeg" {
+			t.Error("Invalid image MIME type")
+		}
+		if assertSize(img.Body, opts.Width, opts.Height) != nil {
+			t.Errorf("Invalid image size, expected: %dx%d", opts.Width, opts.Height)
+		}
+	})
+
+	t.Run("Width defined", func(t *testing.T) {
+		opts := ImageOptions{Width: 300}
+		buf, _ := ioutil.ReadAll(readFile("imaginary.jpg"))
+
+		img, err := Resize(buf, opts)
+		if err != nil {
+			t.Errorf("Cannot process image: %s", err)
+		}
+		if img.Mime != "image/jpeg" {
+			t.Error("Invalid image MIME type")
+		}
+		if err := assertSize(img.Body, 300, 404); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("Width defined with NoCrop=false", func(t *testing.T) {
+		opts := ImageOptions{Width: 300, NoCrop: false, IsDefinedField: IsDefinedField{NoCrop: true}}
+		buf, _ := ioutil.ReadAll(readFile("imaginary.jpg"))
+
+		img, err := Resize(buf, opts)
+		if err != nil {
+			t.Errorf("Cannot process image: %s", err)
+		}
+		if img.Mime != "image/jpeg" {
+			t.Error("Invalid image MIME type")
+		}
+
+		// The original image is 550x740
+		if err := assertSize(img.Body, 300, 740); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("Width defined with NoCrop=true", func(t *testing.T) {
+		opts := ImageOptions{Width: 300, NoCrop: true, IsDefinedField: IsDefinedField{NoCrop: true}}
+		buf, _ := ioutil.ReadAll(readFile("imaginary.jpg"))
+
+		img, err := Resize(buf, opts)
+		if err != nil {
+			t.Errorf("Cannot process image: %s", err)
+		}
+		if img.Mime != "image/jpeg" {
+			t.Error("Invalid image MIME type")
+		}
+
+		// The original image is 550x740
+		if err := assertSize(img.Body, 300, 404); err != nil {
+			t.Error(err)
+		}
+	})
+
 }
 
 func TestImageFit(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -4,6 +4,8 @@ import "gopkg.in/h2non/bimg.v1"
 
 // ImageOptions represent all the supported image transformation params as first level members
 type ImageOptions struct {
+	IsDefinedField
+
 	Width         int
 	Height        int
 	AreaWidth     int
@@ -39,6 +41,20 @@ type ImageOptions struct {
 	Gravity       bimg.Gravity
 	Colorspace    bimg.Interpretation
 	Operations    PipelineOperations
+}
+
+// IsDefinedField holds boolean ImageOptions fields. If true it means the field was specified in the request. This
+// metadata allows for sane usage of default (false) values.
+type IsDefinedField struct {
+	Flip          bool
+	Flop          bool
+	Force         bool
+	Embed         bool
+	NoCrop        bool
+	NoReplicate   bool
+	NoRotation    bool
+	NoProfile     bool
+	StripMetadata bool
 }
 
 // PipelineOperation represents the structure for an operation field.

--- a/params.go
+++ b/params.go
@@ -190,46 +190,55 @@ func coerceOpacity(io *ImageOptions, param interface{}) (err error) {
 
 func coerceFlip(io *ImageOptions, param interface{}) (err error) {
 	io.Flip, err = coerceTypeBool(param)
+	io.IsDefinedField.Flip = true
 	return err
 }
 
 func coerceFlop(io *ImageOptions, param interface{}) (err error) {
 	io.Flop, err = coerceTypeBool(param)
+	io.IsDefinedField.Flop = true
 	return err
 }
 
 func coerceNoCrop(io *ImageOptions, param interface{}) (err error) {
 	io.NoCrop, err = coerceTypeBool(param)
+	io.IsDefinedField.NoCrop = true
 	return err
 }
 
 func coerceNoProfile(io *ImageOptions, param interface{}) (err error) {
 	io.NoProfile, err = coerceTypeBool(param)
+	io.IsDefinedField.NoProfile = true
 	return err
 }
 
 func coerceNoRotation(io *ImageOptions, param interface{}) (err error) {
 	io.NoRotation, err = coerceTypeBool(param)
+	io.IsDefinedField.NoRotation = true
 	return err
 }
 
 func coerceNoReplicate(io *ImageOptions, param interface{}) (err error) {
 	io.NoReplicate, err = coerceTypeBool(param)
+	io.IsDefinedField.NoReplicate = true
 	return err
 }
 
 func coerceForce(io *ImageOptions, param interface{}) (err error) {
 	io.Force, err = coerceTypeBool(param)
+	io.IsDefinedField.Force = true
 	return err
 }
 
 func coerceEmbed(io *ImageOptions, param interface{}) (err error) {
 	io.Embed, err = coerceTypeBool(param)
+	io.IsDefinedField.Embed = true
 	return err
 }
 
 func coerceStripMeta(io *ImageOptions, param interface{}) (err error) {
 	io.StripMetadata, err = coerceTypeBool(param)
+	io.IsDefinedField.StripMetadata = true
 	return err
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -78,7 +78,7 @@ func TestCrop(t *testing.T) {
 func TestResize(t *testing.T) {
 	ts := testServer(controller(Resize))
 	buf := readFile("large.jpg")
-	url := ts.URL + "?width=300"
+	url := ts.URL + "?width=300&nocrop=false"
 	defer ts.Close()
 
 	res, err := http.Post(url, "image/jpeg", buf)
@@ -426,7 +426,7 @@ func assertSize(buf []byte, width, height int) error {
 		return err
 	}
 	if size.Width != width || size.Height != height {
-		return fmt.Errorf("Invalid image size: %dx%d", size.Width, size.Height)
+		return fmt.Errorf("Invalid image size: %dx%d, expected: %dx%d", size.Width, size.Height, width, height)
 	}
 	return nil
 }


### PR DESCRIPTION
The `ImageOptions` boolean fields did not have a way to test if the value was actually requested. With this change we now can. I initially wanted to work with pointer receivers, but that didn't provide for a nice API, so I went with a field named `IsDefinedField` instead.

The `/resize` endpoint will now function according to the documentation, in that it retains an aspect-ratio (when only one dimension is passed along).

This PR changes the default behaviour for the /zoom and the /resize endpoints:
- `/resize` got "fixed" by being according to the documentation.
- `/zoom` **will require `?nocrop=false` to retain the behaviour it had before this change**

_(Enlarge has changes, but the behaviour remains identical. This made sense since both width & height are required)_

Related: https://github.com/h2non/imaginary/issues/232

Since this is an API breaking change, we can:

- bump a minor version And jump to `1.1.0` (imho a new `major` seems overkill)
- Release as a patch `1.0.18` and hope people read the release-notes.. 


_Other notes: We need to increase both unit-tests and functional test coverage._