### PR TITLE
Replace Round function with Ceil in fit method (Black line)

### DIFF
--- a/image.go
+++ b/image.go
@@ -154,10 +154,10 @@ func Fit(buf []byte, o ImageOptions) (Image, error) {
 func calculateDestinationFitDimension(imageWidth, imageHeight, fitWidth, fitHeight int) (int, int) {
 	if imageWidth*fitHeight > fitWidth*imageHeight {
 		// constrained by width
-		fitHeight = int(math.Round(float64(fitWidth) * float64(imageHeight) / float64(imageWidth)))
+		fitHeight = int(math.Ceil(float64(fitWidth) * float64(imageHeight) / float64(imageWidth)))
 	} else {
 		// constrained by height
-		fitWidth = int(math.Round(float64(fitHeight) * float64(imageWidth) / float64(imageHeight)))
+		fitWidth = int(math.Ceil(float64(fitHeight) * float64(imageWidth) / float64(imageHeight)))
 	}
 
 	return fitWidth, fitHeight


### PR DESCRIPTION
There is a problem when fitWidth = 100.234. Round method make fitWidth equals to 100, but it should be 101 (to prevent black line appearing). #249

I don't know Go and how to run tests, so if you have ability to write tests, please, do it.