### PR TITLE
watermarkImage must be in lowerCamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,7 +998,7 @@ Self-documented JSON operation schema:
 - **zoom** - Same as [`/zoom`](#get--post-zoom) endpoint.
 - **convert** - Same as [`/convert`](#get--post-convert) endpoint.
 - **watermark** - Same as [`/watermark`](#get--post-watermark) endpoint.
-- **watermarkimage** - Same as [`/watermarkimage`](#get--post-watermarkimage) endpoint.
+- **watermarkImage** - Same as [`/watermarkimage`](#get--post-watermarkimage) endpoint.
 - **blur** - Same as [`/blur`](#get--post-blur) endpoint.
 
 ###### Example


### PR DESCRIPTION
watermarkImage instead watermarkimage

{"message":"Error while processing the image: Unsupported operation name: watermarkimage","code":1}

https://github.com/h2non/imaginary/blob/cc53838d71e38f2d7163e8ae0280f466ce4f9998/image.go#L29