### PR TITLE
Added custom headers forwarding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Options:
   -enable-url-source        Enable remote HTTP URL image source processing (?url=http://..)
   -enable-placeholder       Enable image response placeholder to be used in case of error [default: false]
   -enable-auth-forwarding   Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors
-  -forward-headers			    Forwards custom headers to the image source server. -enable-url-source flag must be defined.
+  -forward-headers          Forwards custom headers to the image source server. -enable-url-source flag must be defined.
   -enable-url-signature     Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
   -url-signature-key        The URL signature key (32 characters minimum)
   -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas)

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Usage:
   imaginary -enable-placeholder
   imaginary -enable-url-source -placeholder ./placeholder.jpg
   imaginary -enable-url-signature -url-signature-key 4f46feebafc4b5e988f131c4ff8b5997
-  imaginary -enable-url-source -custom-headers X-Custom,X-Token
+  imaginary -enable-url-source -forward-headers X-Custom,X-Token
   imaginary -h | -help
   imaginary -v | -version
 
@@ -315,7 +315,7 @@ Options:
   -enable-url-source        Enable remote HTTP URL image source processing (?url=http://..)
   -enable-placeholder       Enable image response placeholder to be used in case of error [default: false]
   -enable-auth-forwarding   Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors
-  -custom-headers			      Forwards custom headers to the image source server. -enable-url-source flag must be defined.
+  -forward-headers			    Forwards custom headers to the image source server. -enable-url-source flag must be defined.
   -enable-url-signature     Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
   -url-signature-key        The URL signature key (32 characters minimum)
   -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas)

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Usage:
   imaginary -enable-placeholder
   imaginary -enable-url-source -placeholder ./placeholder.jpg
   imaginary -enable-url-signature -url-signature-key 4f46feebafc4b5e988f131c4ff8b5997
+  imaginary -enable-url-source -custom-headers X-Custom,X-Token
   imaginary -h | -help
   imaginary -v | -version
 
@@ -314,6 +315,7 @@ Options:
   -enable-url-source        Enable remote HTTP URL image source processing (?url=http://..)
   -enable-placeholder       Enable image response placeholder to be used in case of error [default: false]
   -enable-auth-forwarding   Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors
+  -custom-headers			      Forwards custom headers to the image source server. -enable-url-source flag must be defined.
   -enable-url-signature     Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
   -url-signature-key        The URL signature key (32 characters minimum)
   -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas)

--- a/imaginary.go
+++ b/imaginary.go
@@ -273,9 +273,10 @@ func parseForwardHeaders(forwardHeaders string) []string {
 	if forwardHeaders == "" {
 		return headers
 	}
+
 	for _, header := range strings.Split(forwardHeaders, ",") {
-		if header != "" {
-			headers = append(headers, strings.TrimSpace(header))
+		if norm := strings.TrimSpace(header); norm != "" {
+			headers = append(headers, norm)
 		}
 	}
 	return headers

--- a/imaginary.go
+++ b/imaginary.go
@@ -38,7 +38,7 @@ var (
 	aCertFile           = flag.String("certfile", "", "TLS certificate file path")
 	aKeyFile            = flag.String("keyfile", "", "TLS private key file path")
 	aAuthorization      = flag.String("authorization", "", "Defines a constant Authorization header value passed to all the image source servers. -enable-url-source flag must be defined. This overwrites authorization headers forwarding behavior via X-Forward-Authorization")
-	aCustomHeaders      = flag.String("forward-headers", "", "Forwards custom headers to the image source server. -enable-url-source flag must be defined.")
+	aForwardHeaders     = flag.String("forward-headers", "", "Forwards custom headers to the image source server. -enable-url-source flag must be defined.")
 	aPlaceholder        = flag.String("placeholder", "", "Image path to image custom placeholder to be used in case of error. Recommended minimum image size is: 1200x1200")
 	aDisableEndpoints   = flag.String("disable-endpoints", "", "Comma separated endpoints to disable. E.g: form,crop,rotate,health")
 	aHTTPCacheTTL       = flag.Int("http-cache-ttl", -1, "The TTL in seconds")
@@ -146,7 +146,7 @@ func main() {
 		HTTPReadTimeout:    *aReadTimeout,
 		HTTPWriteTimeout:   *aWriteTimeout,
 		Authorization:      *aAuthorization,
-		CustomHeaders:      parseCustomHeaders(*aCustomHeaders),
+		ForwardHeaders:     parseForwardHeaders(*aForwardHeaders),
 		AllowedOrigins:     parseOrigins(*aAllowedOrigins),
 		MaxAllowedSize:     *aMaxAllowedSize,
 	}
@@ -268,14 +268,14 @@ func checkHTTPCacheTTL(ttl int) {
 	}
 }
 
-func parseCustomHeaders(customHeaders string) []string {
+func parseForwardHeaders(forwardHeaders string) []string {
 	var headers []string
-	if customHeaders == "" {
+	if forwardHeaders == "" {
 		return headers
 	}
-	for _, header := range strings.Split(customHeaders, ",") {
+	for _, header := range strings.Split(forwardHeaders, ",") {
 		if header != "" {
-			headers = append(headers, header)
+			headers = append(headers, strings.TrimSpace(header))
 		}
 	}
 	return headers

--- a/imaginary.go
+++ b/imaginary.go
@@ -38,7 +38,7 @@ var (
 	aCertFile           = flag.String("certfile", "", "TLS certificate file path")
 	aKeyFile            = flag.String("keyfile", "", "TLS private key file path")
 	aAuthorization      = flag.String("authorization", "", "Defines a constant Authorization header value passed to all the image source servers. -enable-url-source flag must be defined. This overwrites authorization headers forwarding behavior via X-Forward-Authorization")
-	aCustomHeaders      = flag.String("custom-headers", "", "Forwards custom headers to the image source server. -enable-url-source flag must be defined.")
+	aCustomHeaders      = flag.String("forward-headers", "", "Forwards custom headers to the image source server. -enable-url-source flag must be defined.")
 	aPlaceholder        = flag.String("placeholder", "", "Image path to image custom placeholder to be used in case of error. Recommended minimum image size is: 1200x1200")
 	aDisableEndpoints   = flag.String("disable-endpoints", "", "Comma separated endpoints to disable. E.g: form,crop,rotate,health")
 	aHTTPCacheTTL       = flag.Int("http-cache-ttl", -1, "The TTL in seconds")
@@ -65,7 +65,7 @@ Usage:
   imaginary -enable-placeholder
   imaginary -enable-url-source -placeholder ./placeholder.jpg
   imaginary -enable-url-signature -url-signature-key 4f46feebafc4b5e988f131c4ff8b5997
-  imaginary -enable-url-source -custom-headers X-Custom,X-Token
+  imaginary -enable-url-source -forward-headers X-Custom,X-Token
   imaginary -h | -help
   imaginary -v | -version
 
@@ -86,7 +86,7 @@ Options:
   -enable-url-source        Enable remote HTTP URL image source processing
   -enable-placeholder       Enable image response placeholder to be used in case of error [default: false]
   -enable-auth-forwarding   Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors
-  -custom-headers			Forwards custom headers to the image source server. -enable-url-source flag must be defined.
+  -forward-headers          Forwards custom headers to the image source server. -enable-url-source flag must be defined.
   -enable-url-signature     Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
   -url-signature-key        The URL signature key (32 characters minimum)
   -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas)
@@ -268,11 +268,17 @@ func checkHTTPCacheTTL(ttl int) {
 	}
 }
 
-func parseCustomHeaders(headers string) []string {
-	if headers == "" {
-		return []string{}
+func parseCustomHeaders(customHeaders string) []string {
+	var headers []string
+	if customHeaders == "" {
+		return headers
 	}
-	return strings.Split(headers, ",")
+	for _, header := range strings.Split(customHeaders, ",") {
+		if header != "" {
+			headers = append(headers, header)
+		}
+	}
+	return headers
 }
 
 func parseOrigins(origins string) []*url.URL {

--- a/imaginary.go
+++ b/imaginary.go
@@ -38,6 +38,7 @@ var (
 	aCertFile           = flag.String("certfile", "", "TLS certificate file path")
 	aKeyFile            = flag.String("keyfile", "", "TLS private key file path")
 	aAuthorization      = flag.String("authorization", "", "Defines a constant Authorization header value passed to all the image source servers. -enable-url-source flag must be defined. This overwrites authorization headers forwarding behavior via X-Forward-Authorization")
+	aCustomHeaders      = flag.String("custom-headers", "", "Forwards custom headers to the image source server. -enable-url-source flag must be defined.")
 	aPlaceholder        = flag.String("placeholder", "", "Image path to image custom placeholder to be used in case of error. Recommended minimum image size is: 1200x1200")
 	aDisableEndpoints   = flag.String("disable-endpoints", "", "Comma separated endpoints to disable. E.g: form,crop,rotate,health")
 	aHTTPCacheTTL       = flag.Int("http-cache-ttl", -1, "The TTL in seconds")
@@ -64,6 +65,7 @@ Usage:
   imaginary -enable-placeholder
   imaginary -enable-url-source -placeholder ./placeholder.jpg
   imaginary -enable-url-signature -url-signature-key 4f46feebafc4b5e988f131c4ff8b5997
+  imaginary -enable-url-source -custom-headers X-Custom,X-Token
   imaginary -h | -help
   imaginary -v | -version
 
@@ -84,6 +86,7 @@ Options:
   -enable-url-source        Enable remote HTTP URL image source processing
   -enable-placeholder       Enable image response placeholder to be used in case of error [default: false]
   -enable-auth-forwarding   Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors
+  -custom-headers			Forwards custom headers to the image source server. -enable-url-source flag must be defined.
   -enable-url-signature     Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
   -url-signature-key        The URL signature key (32 characters minimum)
   -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas)
@@ -143,6 +146,7 @@ func main() {
 		HTTPReadTimeout:    *aReadTimeout,
 		HTTPWriteTimeout:   *aWriteTimeout,
 		Authorization:      *aAuthorization,
+		CustomHeaders:      parseCustomHeaders(*aCustomHeaders),
 		AllowedOrigins:     parseOrigins(*aAllowedOrigins),
 		MaxAllowedSize:     *aMaxAllowedSize,
 	}
@@ -262,6 +266,13 @@ func checkHTTPCacheTTL(ttl int) {
 	if ttl == 0 {
 		debug("Adding HTTP cache control headers set to prevent caching.")
 	}
+}
+
+func parseCustomHeaders(headers string) []string {
+	if headers == "" {
+		return []string{}
+	}
+	return strings.Split(headers, ",")
 }
 
 func parseOrigins(origins string) []*url.URL {

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ type ServerOptions struct {
 	KeyFile            string
 	Authorization      string
 	Placeholder        string
-	CustomHeaders      []string
+	ForwardHeaders     []string
 	PlaceholderImage   []byte
 	Endpoints          Endpoints
 	AllowedOrigins     []*url.URL

--- a/server.go
+++ b/server.go
@@ -33,6 +33,7 @@ type ServerOptions struct {
 	KeyFile            string
 	Authorization      string
 	Placeholder        string
+	CustomHeaders	   []string
 	PlaceholderImage   []byte
 	Endpoints          Endpoints
 	AllowedOrigins     []*url.URL

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ type ServerOptions struct {
 	KeyFile            string
 	Authorization      string
 	Placeholder        string
-	CustomHeaders	   []string
+	CustomHeaders      []string
 	PlaceholderImage   []byte
 	Endpoints          Endpoints
 	AllowedOrigins     []*url.URL

--- a/source.go
+++ b/source.go
@@ -13,6 +13,7 @@ type SourceConfig struct {
 	Authorization  string
 	MountPath      string
 	Type           ImageSourceType
+	CustomHeaders  []string
 	AllowedOrigins []*url.URL
 	MaxAllowedSize int
 }
@@ -38,6 +39,7 @@ func LoadSources(o ServerOptions) {
 			Authorization:  o.Authorization,
 			AllowedOrigins: o.AllowedOrigins,
 			MaxAllowedSize: o.MaxAllowedSize,
+			CustomHeaders:  o.CustomHeaders,
 		})
 	}
 }

--- a/source.go
+++ b/source.go
@@ -13,7 +13,7 @@ type SourceConfig struct {
 	Authorization  string
 	MountPath      string
 	Type           ImageSourceType
-	CustomHeaders  []string
+	ForwardHeaders []string
 	AllowedOrigins []*url.URL
 	MaxAllowedSize int
 }
@@ -39,7 +39,7 @@ func LoadSources(o ServerOptions) {
 			Authorization:  o.Authorization,
 			AllowedOrigins: o.AllowedOrigins,
 			MaxAllowedSize: o.MaxAllowedSize,
-			CustomHeaders:  o.CustomHeaders,
+			ForwardHeaders: o.ForwardHeaders,
 		})
 	}
 }

--- a/source_http.go
+++ b/source_http.go
@@ -86,8 +86,8 @@ func (s *HTTPImageSource) setAuthorizationHeader(req *http.Request, ireq *http.R
 	}
 }
 
-func (s *HTTPImageSource) setCustomHeaders(req *http.Request, ireq *http.Request) {
-	headers := s.Config.CustomHeaders
+func (s *HTTPImageSource) setForwardHeaders(req *http.Request, ireq *http.Request) {
+	headers := s.Config.ForwardHeaders
 	for _, header := range headers {
 		if header != "" && ireq.Header.Get(header) != "" && req.Header.Get(header) == "" {
 			req.Header.Set(header, ireq.Header.Get(header))
@@ -104,8 +104,8 @@ func newHTTPRequest(s *HTTPImageSource, ireq *http.Request, method string, url *
 	req.Header.Set("User-Agent", "imaginary/"+Version)
 	req.URL = url
 
-	if len(s.Config.CustomHeaders) != 0 {
-		s.setCustomHeaders(req, ireq)
+	if len(s.Config.ForwardHeaders) != 0 {
+		s.setForwardHeaders(req, ireq)
 	}
 
 	// Forward auth header to the target server, if necessary

--- a/source_http.go
+++ b/source_http.go
@@ -89,7 +89,7 @@ func (s *HTTPImageSource) setAuthorizationHeader(req *http.Request, ireq *http.R
 func (s *HTTPImageSource) setForwardHeaders(req *http.Request, ireq *http.Request) {
 	headers := s.Config.ForwardHeaders
 	for _, header := range headers {
-		if header != "" && len(ireq.Header[header]) > 0 {
+		if _,ok := ireq.Header[header]; ok {
 			req.Header.Set(header, ireq.Header.Get(header))
 		}
 	}

--- a/source_http.go
+++ b/source_http.go
@@ -89,7 +89,7 @@ func (s *HTTPImageSource) setAuthorizationHeader(req *http.Request, ireq *http.R
 func (s *HTTPImageSource) setCustomHeaders(req *http.Request, ireq *http.Request) {
 	headers := s.Config.CustomHeaders
 	for _, header := range headers {
-		if header != "" && ireq.Header.Get(header) != "" {
+		if header != "" && ireq.Header.Get(header) != "" && req.Header.Get(header) == "" {
 			req.Header.Set(header, ireq.Header.Get(header))
 		}
 	}

--- a/source_http.go
+++ b/source_http.go
@@ -89,7 +89,7 @@ func (s *HTTPImageSource) setAuthorizationHeader(req *http.Request, ireq *http.R
 func (s *HTTPImageSource) setForwardHeaders(req *http.Request, ireq *http.Request) {
 	headers := s.Config.ForwardHeaders
 	for _, header := range headers {
-		if header != "" && ireq.Header.Get(header) != "" && req.Header.Get(header) == "" {
+		if header != "" && len(ireq.Header[header]) > 0 {
 			req.Header.Set(header, ireq.Header.Get(header))
 		}
 	}

--- a/source_http.go
+++ b/source_http.go
@@ -86,6 +86,15 @@ func (s *HTTPImageSource) setAuthorizationHeader(req *http.Request, ireq *http.R
 	}
 }
 
+func (s *HTTPImageSource) setCustomHeaders(req *http.Request, ireq *http.Request) {
+	headers := s.Config.CustomHeaders
+	for _, header := range headers {
+		if header != "" {
+			req.Header.Set(header, ireq.Header.Get(header))
+		}
+	}
+}
+
 func parseURL(request *http.Request) (*url.URL, error) {
 	return url.Parse(request.URL.Query().Get(URLQueryKey))
 }
@@ -98,6 +107,10 @@ func newHTTPRequest(s *HTTPImageSource, ireq *http.Request, method string, url *
 	// Forward auth header to the target server, if necessary
 	if s.Config.AuthForwarding || s.Config.Authorization != "" {
 		s.setAuthorizationHeader(req, ireq)
+	}
+
+	if len(s.Config.CustomHeaders) != 0 {
+		s.setCustomHeaders(req, ireq)
 	}
 
 	return req

--- a/source_http.go
+++ b/source_http.go
@@ -89,7 +89,7 @@ func (s *HTTPImageSource) setAuthorizationHeader(req *http.Request, ireq *http.R
 func (s *HTTPImageSource) setCustomHeaders(req *http.Request, ireq *http.Request) {
 	headers := s.Config.CustomHeaders
 	for _, header := range headers {
-		if header != "" {
+		if header != "" && ireq.Header.Get(header) != "" {
 			req.Header.Set(header, ireq.Header.Get(header))
 		}
 	}
@@ -104,13 +104,13 @@ func newHTTPRequest(s *HTTPImageSource, ireq *http.Request, method string, url *
 	req.Header.Set("User-Agent", "imaginary/"+Version)
 	req.URL = url
 
+	if len(s.Config.CustomHeaders) != 0 {
+		s.setCustomHeaders(req, ireq)
+	}
+
 	// Forward auth header to the target server, if necessary
 	if s.Config.AuthForwarding || s.Config.Authorization != "" {
 		s.setAuthorizationHeader(req, ireq)
-	}
-
-	if len(s.Config.CustomHeaders) != 0 {
-		s.setCustomHeaders(req, ireq)
 	}
 
 	return req

--- a/source_http_test.go
+++ b/source_http_test.go
@@ -134,13 +134,13 @@ func TestHttpImageSourceForwardHeaders(t *testing.T) {
 		r, _ := http.NewRequest(http.MethodGet, "http://foo/bar?url=http://bar.com", nil)
 		r.Header.Set(header, "foobar")
 
-		source := &HTTPImageSource{&SourceConfig{CustomHeaders: cases}}
+		source := &HTTPImageSource{&SourceConfig{ForwardHeaders: cases}}
 		if !source.Matches(r) {
 			t.Fatal("Cannot match the request")
 		}
 
 		oreq := &http.Request{Header: make(http.Header)}
-		source.setCustomHeaders(oreq, r)
+		source.setForwardHeaders(oreq, r)
 
 		if oreq.Header.Get(header) != "foobar" {
 			t.Fatal("Missmatch custom header")
@@ -159,7 +159,7 @@ func TestHttpImageSourceNotForwardHeaders(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://foo/bar?url="+url.String(), nil)
 	r.Header.Set("Not-Forward", "foobar")
 
-	source := &HTTPImageSource{&SourceConfig{CustomHeaders: cases}}
+	source := &HTTPImageSource{&SourceConfig{ForwardHeaders: cases}}
 	if !source.Matches(r) {
 		t.Fatal("Cannot match the request")
 	}
@@ -182,7 +182,7 @@ func TestHttpImageSourceForwardedHeadersNotOverride(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://foo/bar?url="+url.String() , nil)
 	r.Header.Set("Authorization", "foobar")
 	
-	source := &HTTPImageSource{&SourceConfig{Authorization: "ValidAPIKey", CustomHeaders: cases}}
+	source := &HTTPImageSource{&SourceConfig{Authorization: "ValidAPIKey", ForwardHeaders: cases}}
 	if !source.Matches(r) {
 		t.Fatal("Cannot match the request")
 	}
@@ -205,7 +205,7 @@ func TestHttpImageSourceCaseSensitivityInForwardedHeaders(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://foo/bar?url="+url.String(), nil)
 	r.Header.Set("x-custom", "foobar")
 
-	source := &HTTPImageSource{&SourceConfig{CustomHeaders: cases}}
+	source := &HTTPImageSource{&SourceConfig{ForwardHeaders: cases}}
 	if !source.Matches(r) {
 		t.Fatal("Cannot match the request")
 	}
@@ -224,13 +224,13 @@ func TestHttpImageSourceEmptyForwardedHeaders(t *testing.T) {
 
 	r, _ := http.NewRequest(http.MethodGet, "http://foo/bar?url="+url.String(), nil)
 
-	source := &HTTPImageSource{&SourceConfig{CustomHeaders: cases}}
+	source := &HTTPImageSource{&SourceConfig{ForwardHeaders: cases}}
 	if !source.Matches(r) {
 		t.Fatal("Cannot match the request")
 	}
 
-	if len(source.Config.CustomHeaders) != 0 {
-		t.Log(source.Config.CustomHeaders)
+	if len(source.Config.ForwardHeaders) != 0 {
+		t.Log(source.Config.ForwardHeaders)
 		t.Fatal("Setted empty custom header")
 	}
 

--- a/source_http_test.go
+++ b/source_http_test.go
@@ -124,6 +124,30 @@ func TestHttpImageSourceForwardAuthHeader(t *testing.T) {
 	}
 }
 
+func TestHttpImageSourceCustomHeaders(t *testing.T) {
+	cases := []string{
+		"X-Custom",
+		"X-Token",
+	}
+
+	for _, header := range cases {
+		r, _ := http.NewRequest(http.MethodGet, "http://foo/bar?url=http://bar.com", nil)
+		r.Header.Set(header, "foobar")
+
+		source := &HTTPImageSource{&SourceConfig{CustomHeaders: cases}}
+		if !source.Matches(r) {
+			t.Fatal("Cannot match the request")
+		}
+
+		oreq := &http.Request{Header: make(http.Header)}
+		source.setCustomHeaders(oreq, r)
+
+		if oreq.Header.Get(header) != "foobar" {
+			t.Fatal("Missmatch custom header")
+		}
+	}
+}
+
 func TestHttpImageSourceError(t *testing.T) {
 	var err error
 


### PR DESCRIPTION
Hi, I added support to forward any header to the image source server. Maybe can help if the source server checks those headers for track information of API consumption and if uses another custom header for authorization.

I'm a beginner of Go so any modification or advice are welcome.