### PR TITLE
Width and height are required in thumbnail request

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,8 +794,8 @@ Accepts: `image/*, multipart/form-data`. Content-Type: `image/*`
 
 ##### Allowed params
 
-- width `int`
-- height `int`
+- width `int` `required`
+- height `int` `required`
 - quality `int` (JPEG-only)
 - compression `int` (PNG-only)
 - type `string`


### PR DESCRIPTION
Get an error from request `/thumbnail`:

`Error while processing the image: Missing required params: width or height`