### PR TITLE
Implement wildcard for paths for the allowed-origins option

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ imaginary can be configured to block all requests for images with a src URL this
 | ------------------------- | --------- | -------- |
 | `--allowed-origins s3.amazonaws.com/some-bucket/` | `s3.amazonaws.com/some-bucket/images/image.png` | VALID |
 | `--allowed-origins s3.amazonaws.com/some-bucket/` | `s3.amazonaws.com/images/image.png` | NOT VALID (no matching basepath) |
+| `--allowed-origins s3.amazonaws.com/some-*` | `s3.amazonaws.com/some-bucket/images/image.png` | VALID |
 | `--allowed-origins *.amazonaws.com/some-bucket/` | `anysubdomain.amazonaws.com/some-bucket/images/image.png` | VALID |
 | `--allowed-origins *.amazonaws.com` | `anysubdomain.amazonaws.comimages/image.png` | VALID |
 | `--allowed-origins *.amazonaws.com` | `www.notaws.comimages/image.png` | NOT VALID (no matching host) |

--- a/imaginary.go
+++ b/imaginary.go
@@ -293,8 +293,13 @@ func parseOrigins(origins string) []*url.URL {
 			continue
 		}
 
-		if u.Path != "" && u.Path[len(u.Path)-1:] != "/" {
-			u.Path += "/"
+		if u.Path != "" {
+			var lastChar = u.Path[len(u.Path)-1:]
+			if (lastChar == "*") {
+				u.Path = strings.TrimSuffix(u.Path, "*")
+			} else if (lastChar != "/") {
+				u.Path += "/"
+			}
 		}
 
 		urls = append(urls, u)

--- a/source_http.go
+++ b/source_http.go
@@ -122,6 +122,7 @@ func shouldRestrictOrigin(url *url.URL, origins []*url.URL) bool {
 	}
 
 	for _, origin := range origins {
+
 		if origin.Host == url.Host {
 			if strings.HasPrefix(url.Path, origin.Path) {
 				return false

--- a/source_http.go
+++ b/source_http.go
@@ -122,7 +122,6 @@ func shouldRestrictOrigin(url *url.URL, origins []*url.URL) bool {
 	}
 
 	for _, origin := range origins {
-
 		if origin.Host == url.Host {
 			if strings.HasPrefix(url.Path, origin.Path) {
 				return false
@@ -130,7 +129,6 @@ func shouldRestrictOrigin(url *url.URL, origins []*url.URL) bool {
 		}
 
 		if origin.Host[0:2] == "*." {
-
 			// Testing if "*.example.org" matches "example.org"
 			if url.Host == origin.Host[2:] {
 				if strings.HasPrefix(url.Path, origin.Path) {

--- a/source_http_test.go
+++ b/source_http_test.go
@@ -315,6 +315,10 @@ func TestShouldRestrictOrigin(t *testing.T) {
 		"https://some.s3.bucket.on.aws.org/my/bucket1/,https://some.s3.bucket.on.aws.org/my/bucket2/",
 	)
 
+	pathWildCard := parseOrigins(
+		"https://some.s3.bucket.on.aws.org/my-bucket-name*",
+	)
+
 	t.Run("Plain origin", func(t *testing.T) {
 		testURL := createURL("https://example.org/logo.jpg", t)
 
@@ -420,6 +424,19 @@ func TestShouldRestrictOrigin(t *testing.T) {
 
 		if shouldRestrictOrigin(testURL, with2Buckets) {
 			t.Errorf("Expected '%s' to be allowed with origins: %+v", testURL, with2Buckets)
+		}
+	})
+
+	t.Run("Path wildcard", func(t *testing.T) {
+		testURL := createURL("https://some.s3.bucket.on.aws.org/my-bucket-name/logo.jpg", t)
+		testURLFail := createURL("https://some.s3.bucket.on.aws.org/my-other-bucket-name/logo.jpg", t)
+
+		if shouldRestrictOrigin(testURL, pathWildCard) {
+			t.Errorf("Expected '%s' to be allowed with origins: %+v", testURL, pathWildCard)
+		}
+
+		if !shouldRestrictOrigin(testURLFail, pathWildCard) {
+			t.Errorf("Expected '%s' to be restricted with origins: %+v", testURLFail, pathWildCard)
 		}
 	})
 


### PR DESCRIPTION
At work we are using many different buckets

1. https://storage.googleapis.com/company-dev-bucket1
2. https://storage.googleapis.com/company-dev-bucket2
3. https://storage.googleapis.com/company-dev-bucket3

This the reason I need this new feature.
