### PR TITLE
[improvement/log-levels] Add support set log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Assuming that you want to provide a high availability to deal efficiently with, 
         |==============|
         |   Balancer   |
         |==============|
-           |       |   
+           |       |
           /         \
          /           \
         /             \
@@ -305,7 +305,7 @@ Options:
   -forward-headers          Forwards custom headers to the image source server. -enable-url-source flag must be defined.
   -enable-url-signature     Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
   -url-signature-key        The URL signature key (32 characters minimum)
-  -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas). Note: Origins are validated against host *AND* path. 
+  -allowed-origins <urls>   Restrict remote image source processing to certain origins (separated by commas). Note: Origins are validated against host *AND* path.
   -max-allowed-size <bytes> Restrict maximum size of http image source (in bytes)
   -certfile <path>          TLS certificate file path
   -keyfile <path>           TLS private key file path
@@ -316,6 +316,8 @@ Options:
   -mrelease <num>           OS memory release interval in seconds [default: 30]
   -cpus <num>               Number of used cpu cores.
                             (default for current machine is 8 cores)
+  -log-level                Set log level for http-server. E.g: info,warning,error [default: info].
+                            Or can use the environment variable GOLANG_LOG=info.
 ```
 
 Start the server in a custom port:
@@ -402,6 +404,11 @@ DEBUG=* imaginary -p 8080
 Or filter debug output by package:
 ```
 DEBUG=imaginary imaginary -p 8080
+```
+
+Disable info logs:
+```
+GOLANG_LOG=error imaginary -p 8080
 ```
 
 #### Examples

--- a/imaginary.go
+++ b/imaginary.go
@@ -48,6 +48,7 @@ var (
 	aBurst              = flag.Int("burst", 100, "Throttle burst max cache size")
 	aMRelease           = flag.Int("mrelease", 30, "OS memory release interval in seconds")
 	aCpus               = flag.Int("cpus", runtime.GOMAXPROCS(-1), "Number of cpu cores to use")
+	aLogLevel           = flag.String("log-level", "info", "Define log level for http-server. E.g: info,warning,error")
 )
 
 const usage = `imaginary %s
@@ -100,6 +101,8 @@ Options:
   -mrelease <num>           OS memory release interval in seconds [default: 30]
   -cpus <num>               Number of used cpu cores.
                             (default for current machine is %d cores)
+  -log-level                Set log level for http-server. E.g: info,warning,error [default: info].
+                            Or can use the environment variable GOLANG_LOG=info.
 `
 
 type URLSignature struct {
@@ -149,6 +152,7 @@ func main() {
 		ForwardHeaders:     parseForwardHeaders(*aForwardHeaders),
 		AllowedOrigins:     parseOrigins(*aAllowedOrigins),
 		MaxAllowedSize:     *aMaxAllowedSize,
+		LogLevel:           getLogLevel(*aLogLevel),
 	}
 
 	// Show warning if gzip flag is passed
@@ -233,6 +237,13 @@ func getURLSignature(key string) URLSignature {
 	}
 
 	return URLSignature{key}
+}
+
+func getLogLevel(logLevel string) string {
+	if logLevelEnv := os.Getenv("GOLANG_LOG"); logLevelEnv != "" {
+		logLevel = logLevelEnv
+	}
+	return logLevel
 }
 
 func showUsage() {

--- a/log_test.go
+++ b/log_test.go
@@ -13,7 +13,7 @@ func (fake fakeWriter) Write(buf []byte) (int, error) {
 	return fake(buf)
 }
 
-func TestLog(t *testing.T) {
+func TestLogInfo(t *testing.T) {
 	var buf []byte
 	writer := fakeWriter(func(b []byte) (int, error) {
 		buf = b
@@ -21,7 +21,7 @@ func TestLog(t *testing.T) {
 	})
 
 	noopHandler := func(w http.ResponseWriter, r *http.Request) {}
-	log := NewLog(http.HandlerFunc(noopHandler), writer)
+	log := NewLog(http.HandlerFunc(noopHandler), writer, "info")
 
 	ts := httptest.NewServer(log)
 	defer ts.Close()
@@ -35,6 +35,30 @@ func TestLog(t *testing.T) {
 	if strings.Contains(data, http.MethodGet) == false ||
 		strings.Contains(data, "HTTP/1.1") == false ||
 		strings.Contains(data, " 200 ") == false {
+		t.Fatalf("Invalid log output: %s", data)
+	}
+}
+
+func TestLogError(t *testing.T) {
+	var buf []byte
+	writer := fakeWriter(func(b []byte) (int, error) {
+		buf = b
+		return 0, nil
+	})
+
+	noopHandler := func(w http.ResponseWriter, r *http.Request) {}
+	log := NewLog(http.HandlerFunc(noopHandler), writer, "error")
+
+	ts := httptest.NewServer(log)
+	defer ts.Close()
+
+	_, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := string(buf)
+	if data != "" {
 		t.Fatalf("Invalid log output: %s", data)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ type ServerOptions struct {
 	PlaceholderImage   []byte
 	Endpoints          Endpoints
 	AllowedOrigins     []*url.URL
+	LogLevel           string
 }
 
 // Endpoints represents a list of endpoint names to disable.
@@ -56,7 +57,7 @@ func (e Endpoints) IsValid(r *http.Request) bool {
 
 func Server(o ServerOptions) error {
 	addr := o.Address + ":" + strconv.Itoa(o.Port)
-	handler := NewLog(NewServerMux(o), os.Stdout)
+	handler := NewLog(NewServerMux(o), os.Stdout, o.LogLevel)
 
 	server := &http.Server{
 		Addr:           addr,


### PR DESCRIPTION
It's an implementation to add basic support for set log levels: `info`, `warning` and `error`.

The `info` logs don't generate any value when this microservice It's used in a big cluster at Kubernetes.

It's a solution for this issue https://github.com/h2non/imaginary/issues/182