### PR TITLE
fix(pipeline): add missing autorate

### DIFF
--- a/image.go
+++ b/image.go
@@ -21,6 +21,7 @@ var OperationsMap = map[string]Operation{
 	"enlarge":        Enlarge,
 	"extract":        Extract,
 	"rotate":         Rotate,
+	"autorotate":     AutoRotate,
 	"flip":           Flip,
 	"flop":           Flop,
 	"thumbnail":      Thumbnail,


### PR DESCRIPTION
`autorotate` is listed among supported operations in pipeline but is not in pipeline operations map, therefore throwing an error.