### PR TITLE
Also set the vary header when an error occurs

### DIFF
--- a/controllers.go
+++ b/controllers.go
@@ -119,6 +119,10 @@ func imageHandler(w http.ResponseWriter, r *http.Request, buf []byte, operation 
 
 	image, err := operation.Run(buf, opts)
 	if err != nil {
+		// Ensure the Vary header is set when an error occurs
+		if vary != "" {
+			w.Header().Set("Vary", vary)
+		}
 		ErrorReply(r, w, NewError("Error while processing the image: "+err.Error(), http.StatusBadRequest), o)
 		return
 	}


### PR DESCRIPTION
Sets the vary header when an error occurs, and the vary header is needed due to the type=auto option. Fixes https://github.com/h2non/imaginary/issues/278