### PR TITLE
added ruby client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Assuming that you want to provide a high availability to deal efficiently with, 
 ## Clients
 
 - [node.js](https://github.com/h2non/node-imaginary)
+- [ruby](https://gitlab.com/azolf/imaginary-ruby)
 
 Feel free to send a PR if you created a client for other language.
 


### PR DESCRIPTION
I have a created a ruby gem which could be used with a imaginary server and interact with it easily.
You could check the gem at [RubyGems](https://rubygems.org/gems/ruby_imaginary)
or check out the [Gitlab Repo](https://gitlab.com/azolf/imaginary-ruby) for it.