### PR TITLE
handling urls encoded with url.QueryUnescape

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ benchmark: build
 
 docker-build:
 	@echo "$(OK_COLOR)==> Building Docker image$(NO_COLOR)"
-	docker build --no-cache=true -t h2non/imaginary:$(VERSION) .
+	docker build --no-cache=true --build-arg IMAGINARY_VERSION=$(VERSION) -t h2non/imaginary:$(VERSION) .
 
 docker-push:
 	@echo "$(OK_COLOR)==> Pushing Docker image v$(VERSION) $(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ benchmark: build
 
 docker-build:
 	@echo "$(OK_COLOR)==> Building Docker image$(NO_COLOR)"
-	docker build --no-cache=true --build-arg IMAGINARY_VERSION=$(VERSION) -t slav123/imaginary:$(VERSION) .
+	docker build --no-cache=true -t h2non/imaginary:$(VERSION) .
 
 docker-push:
 	@echo "$(OK_COLOR)==> Pushing Docker image v$(VERSION) $(NO_COLOR)"
-	docker push slav123/imaginary:$(VERSION)
+	docker push h2non/imaginary:$(VERSION)
 
 docker: docker-build docker-push
 

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ benchmark: build
 
 docker-build:
 	@echo "$(OK_COLOR)==> Building Docker image$(NO_COLOR)"
-	docker build --no-cache=true --build-arg IMAGINARY_VERSION=$(VERSION) -t h2non/imaginary:$(VERSION) .
+	docker build --no-cache=true --build-arg IMAGINARY_VERSION=$(VERSION) -t slav123/imaginary:$(VERSION) .
 
 docker-push:
 	@echo "$(OK_COLOR)==> Pushing Docker image v$(VERSION) $(NO_COLOR)"
-	docker push h2non/imaginary:$(VERSION)
+	docker push slav123/imaginary:$(VERSION)
 
 docker: docker-build docker-push
 

--- a/controllers.go
+++ b/controllers.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"mime"
-	"path"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 
@@ -16,14 +16,14 @@ import (
 func indexController(o ServerOptions) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != path.Join(o.PathPrefix, "/") {
-				ErrorReply(r, w, ErrNotFound, ServerOptions{})
-				return
+			ErrorReply(r, w, ErrNotFound, ServerOptions{})
+			return
 		}
 
 		body, _ := json.Marshal(Versions{
-				Version,
-				bimg.Version,
-				bimg.VipsVersion,
+			Version,
+			bimg.Version,
+			bimg.VipsVersion,
 		})
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
@@ -142,34 +142,34 @@ func imageHandler(w http.ResponseWriter, r *http.Request, buf []byte, operation 
 func formController(o ServerOptions) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		operations := []struct {
-				name   string
-				method string
-				args   string
+			name   string
+			method string
+			args   string
 		}{
-				{"Resize", "resize", "width=300&height=200&type=jpeg"},
-				{"Force resize", "resize", "width=300&height=200&force=true"},
-				{"Crop", "crop", "width=300&quality=95"},
-				{"SmartCrop", "crop", "width=300&height=260&quality=95&gravity=smart"},
-				{"Extract", "extract", "top=100&left=100&areawidth=300&areaheight=150"},
-				{"Enlarge", "enlarge", "width=1440&height=900&quality=95"},
-				{"Rotate", "rotate", "rotate=180"},
-				{"AutoRotate", "autorotate", "quality=90"},
-				{"Flip", "flip", ""},
-				{"Flop", "flop", ""},
-				{"Thumbnail", "thumbnail", "width=100"},
-				{"Zoom", "zoom", "factor=2&areawidth=300&top=80&left=80"},
-				{"Color space (black&white)", "resize", "width=400&height=300&colorspace=bw"},
-				{"Add watermark", "watermark", "textwidth=100&text=Hello&font=sans%2012&opacity=0.5&color=255,200,50"},
-				{"Convert format", "convert", "type=png"},
-				{"Image metadata", "info", ""},
-				{"Gaussian blur", "blur", "sigma=15.0&minampl=0.2"},
-				{"Pipeline (image reduction via multiple transformations)", "pipeline", "operations=%5B%7B%22operation%22:%20%22crop%22,%20%22params%22:%20%7B%22width%22:%20300,%20%22height%22:%20260%7D%7D,%20%7B%22operation%22:%20%22convert%22,%20%22params%22:%20%7B%22type%22:%20%22webp%22%7D%7D%5D"},
+			{"Resize", "resize", "width=300&height=200&type=jpeg"},
+			{"Force resize", "resize", "width=300&height=200&force=true"},
+			{"Crop", "crop", "width=300&quality=95"},
+			{"SmartCrop", "crop", "width=300&height=260&quality=95&gravity=smart"},
+			{"Extract", "extract", "top=100&left=100&areawidth=300&areaheight=150"},
+			{"Enlarge", "enlarge", "width=1440&height=900&quality=95"},
+			{"Rotate", "rotate", "rotate=180"},
+			{"AutoRotate", "autorotate", "quality=90"},
+			{"Flip", "flip", ""},
+			{"Flop", "flop", ""},
+			{"Thumbnail", "thumbnail", "width=100"},
+			{"Zoom", "zoom", "factor=2&areawidth=300&top=80&left=80"},
+			{"Color space (black&white)", "resize", "width=400&height=300&colorspace=bw"},
+			{"Add watermark", "watermark", "textwidth=100&text=Hello&font=sans%2012&opacity=0.5&color=255,200,50"},
+			{"Convert format", "convert", "type=png"},
+			{"Image metadata", "info", ""},
+			{"Gaussian blur", "blur", "sigma=15.0&minampl=0.2"},
+			{"Pipeline (image reduction via multiple transformations)", "pipeline", "operations=%5B%7B%22operation%22:%20%22crop%22,%20%22params%22:%20%7B%22width%22:%20300,%20%22height%22:%20260%7D%7D,%20%7B%22operation%22:%20%22convert%22,%20%22params%22:%20%7B%22type%22:%20%22webp%22%7D%7D%5D"},
 		}
 
 		html := "<html><body>"
 
 		for _, form := range operations {
-				html += fmt.Sprintf(`
+			html += fmt.Sprintf(`
 		<h1>%s</h1>
 		<form method="POST" action="%s?%s" enctype="multipart/form-data">
 		<input type="file" name="file" />

--- a/source_http.go
+++ b/source_http.go
@@ -96,7 +96,17 @@ func (s *HTTPImageSource) setForwardHeaders(req *http.Request, ireq *http.Reques
 }
 
 func parseURL(request *http.Request) (*url.URL, error) {
-	return url.Parse(request.URL.Query().Get(URLQueryKey))
+	queryUrl := request.URL.Query().Get("url")
+
+	if strings.Contains(queryUrl, "%") {
+		var err error
+		queryUrl, err = url.QueryUnescape(queryUrl)
+		if err != nil {
+			log.Printf("failed to unesacpe url")
+		}
+	}
+
+	return url.Parse(queryUrl)
 }
 
 func newHTTPRequest(s *HTTPImageSource, ireq *http.Request, method string, url *url.URL) *http.Request {

--- a/source_http.go
+++ b/source_http.go
@@ -43,11 +43,12 @@ func (s *HTTPImageSource) fetchImage(murl *url.URL, ireq *http.Request) ([]byte,
 		var err error
 		queryURL, err = url.QueryUnescape(queryURL)
 		if err != nil {
-			fmt.Printf("failed to unesacpe url: %v", err)
+			return nil, fmt.Errorf("failed to unescape url: %v", err)
 		}
-		fmt.Printf("queryURL unescape: %s\n", queryURL)
-
-		murl, _ = url.Parse(queryURL)
+		murl, err = url.Parse(queryURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse Url: %v", err)
+		}
 	}
 
 	// Check remote image size by fetching HTTP Headers


### PR DESCRIPTION
I had an issue where imaginary couldn't properly download images living in AWS S3 bucket, and they were signed. I figure out that we can just use [url.QueryEscape](https://pkg.go.dev/net/url#QueryUnescape) to encode them, and then Unescape them during the process later on. 

So with this change you can pass url like these `https%3A%2F%2Fbucket.s3-accelerate.amazonaws.com%2F1%2F1.jpg%3FX-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3xxx%252F20210903%252Feu-central-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20210903T192653Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26x-id%3DGetObject%26X-Amz-Signature%3zzz`