### PR TITLE
updated docker builder OS to go version 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GOLANG_VERSION=1.14
-FROM golang:${GOLANG_VERSION} as builder
+ARG GOLANG_VERSION=1.17
+FROM golang:${GOLANG_VERSION}-buster as builder
 
 ARG IMAGINARY_VERSION=dev
 ARG LIBVIPS_VERSION=8.10.0
@@ -50,7 +50,7 @@ RUN go mod download
 COPY . .
 
 # Run quality control
-RUN go test -test.v -test.race -test.covermode=atomic .
+RUN go test ./... -test.v -race -test.coverprofile=atomic .
 RUN golangci-lint run .
 
 # Compile imaginary


### PR DESCRIPTION
Updated docker builder OS to the latest version of Go

This also requires specifying a `buster` build, as it seems like the default for the 1.17 tag now goes to an alpine build, causing incompatibilities with the runtime stage container

Also updates `go test` with the correct flags for 1.17 
 - `test.covermode` is now `test.coverprofile`

 - `-test.race` is now just `-race`

requested in #360 