### PR TITLE
Return with and heigh of the generated images

### DIFF
--- a/controllers.go
+++ b/controllers.go
@@ -133,7 +133,7 @@ func imageHandler(w http.ResponseWriter, r *http.Request, buf []byte, operation 
 	// Expose Content-Length response header
 	w.Header().Set("Content-Length", strconv.Itoa(len(image.Body)))
 	w.Header().Set("Content-Type", image.Mime)
-	if image.Mime != "application/json" {
+	if image.Mime != "application/json" && o.ReturnSize {
 		meta, err := bimg.Metadata(image.Body)
 		if err == nil {
 			w.Header().Set("X-Image-Width", strconv.Itoa(meta.Size.Width))

--- a/controllers.go
+++ b/controllers.go
@@ -133,6 +133,13 @@ func imageHandler(w http.ResponseWriter, r *http.Request, buf []byte, operation 
 	// Expose Content-Length response header
 	w.Header().Set("Content-Length", strconv.Itoa(len(image.Body)))
 	w.Header().Set("Content-Type", image.Mime)
+	if image.Mime != "application/json" {
+		meta, err := bimg.Metadata(image.Body)
+		if err == nil {
+			w.Header().Set("X-Image-Width", strconv.Itoa(meta.Size.Width))
+			w.Header().Set("X-Image-Height", strconv.Itoa(meta.Size.Height))
+		}
+	}
 	if vary != "" {
 		w.Header().Set("Vary", vary)
 	}

--- a/controllers.go
+++ b/controllers.go
@@ -136,8 +136,8 @@ func imageHandler(w http.ResponseWriter, r *http.Request, buf []byte, operation 
 	if image.Mime != "application/json" && o.ReturnSize {
 		meta, err := bimg.Metadata(image.Body)
 		if err == nil {
-			w.Header().Set("X-Image-Width", strconv.Itoa(meta.Size.Width))
-			w.Header().Set("X-Image-Height", strconv.Itoa(meta.Size.Height))
+			w.Header().Set("Image-Width", strconv.Itoa(meta.Size.Width))
+			w.Header().Set("Image-Height", strconv.Itoa(meta.Size.Height))
 		}
 	}
 	if vary != "" {

--- a/imaginary.go
+++ b/imaginary.go
@@ -50,6 +50,7 @@ var (
 	aMRelease           = flag.Int("mrelease", 30, "OS memory release interval in seconds")
 	aCpus               = flag.Int("cpus", runtime.GOMAXPROCS(-1), "Number of cpu cores to use")
 	aLogLevel           = flag.String("log-level", "info", "Define log level for http-server. E.g: info,warning,error")
+	aReturnSize         = flag.Bool("return-size", false, "Return the image size in the HTTP headers")
 )
 
 const usage = `imaginary %s
@@ -106,6 +107,7 @@ Options:
                              (default for current machine is %d cores)
   -log-level                 Set log level for http-server. E.g: info,warning,error [default: info].
                              Or can use the environment variable GOLANG_LOG=info.
+  -return-size               Return the image size with X-Width and X-Height HTTP header. [default: disabled].
 `
 
 type URLSignature struct {
@@ -157,6 +159,7 @@ func main() {
 		AllowedOrigins:     parseOrigins(*aAllowedOrigins),
 		MaxAllowedSize:     *aMaxAllowedSize,
 		LogLevel:           getLogLevel(*aLogLevel),
+		ReturnSize:         *aReturnSize,
 	}
 
 	// Show warning if gzip flag is passed

--- a/server.go
+++ b/server.go
@@ -43,6 +43,7 @@ type ServerOptions struct {
 	Endpoints          Endpoints
 	AllowedOrigins     []*url.URL
 	LogLevel           string
+	ReturnSize         bool
 }
 
 // Endpoints represents a list of endpoint names to disable.

--- a/type.go
+++ b/type.go
@@ -27,7 +27,8 @@ func IsImageMimeTypeSupported(mime string) bool {
 		format = "svg"
 	}
 
-	return bimg.IsTypeNameSupported(format)
+	// Tmp hack to see if this fix an issue
+	return true // bimg.IsTypeNameSupported(format)
 }
 
 // ImageType returns the image type based on the given image type alias.

--- a/type.go
+++ b/type.go
@@ -27,8 +27,7 @@ func IsImageMimeTypeSupported(mime string) bool {
 		format = "svg"
 	}
 
-	// Tmp hack to see if this fix an issue
-	return true // bimg.IsTypeNameSupported(format)
+	return bimg.IsTypeNameSupported(format)
 }
 
 // ImageType returns the image type based on the given image type alias.


### PR DESCRIPTION
Use case:

When using the fit image transformation, it is helpful to know the size
of the resulting image without having to either read the image locally
or do another request to the info endpoint.

Used in: https://github.com/nextcloud/server/pull/24166

Todos:

- [ ] Update doc (readme)
- [ ] Maybe add this as an option as depending on the use-case, this might not be wanted