### PR TITLE
Updated Dockerfile to Bullseye and updated libvips

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 **/*~
+.devcontainer
+.github
 .git
+Dockerfile
+docker-compose.yml


### PR DESCRIPTION
I made this change in my fork and I thought it would help upstream too.

The core of the change was updating the base image from Buster to Bullseye. By doing that, libjemalloc is now available in the official Debian repos in the version that was used before, so it is possible to install the package without having to build it from source: this should keep the container much smaller.

Also, I've updated libvips to the latest version.