### PR TITLE
Added dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,6 +47,3 @@ RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 # [Optional] Uncomment the next lines to use go get to install anything else you need
 # USER vscode
 # RUN go get -x <your-dependency-or-tool>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,52 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/go/.devcontainer/base.Dockerfile
+
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+ARG VARIANT="1.17-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# Versions of libvips and golanci-lint
+ARG LIBVIPS_VERSION=8.12.2
+ARG GOLANGCILINT_VERSION=1.29.0
+
+# Install additional OS packages
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update && \
+  apt-get install --no-install-recommends -y \
+  ca-certificates \
+  automake build-essential curl \
+  procps    libopenexr25 libmagickwand-6.q16-6 libpango1.0-0 libmatio11 \
+  libopenslide0 libjemalloc2 gobject-introspection gtk-doc-tools \
+  libglib2.0-0 libglib2.0-dev libjpeg62-turbo libjpeg62-turbo-dev \
+  libpng16-16 libpng-dev libwebp6 libwebpmux3 libwebpdemux2 libwebp-dev \
+  libtiff5 libtiff5-dev libgif7 libgif-dev libexif12 libexif-dev \
+  libxml2 libxml2-dev libpoppler-glib8 libpoppler-glib-dev \
+  swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev \
+  libcfitsio9 libcfitsio-dev libgsf-1-114 libgsf-1-dev fftw3 fftw3-dev \
+  liborc-0.4-0 liborc-0.4-dev librsvg2-2 librsvg2-dev libimagequant0 \
+  libimagequant-dev libheif1 libheif-dev && \
+  cd /tmp && \
+  curl -fsSLO https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.gz && \
+  tar zvxf vips-${LIBVIPS_VERSION}.tar.gz && \
+  cd /tmp/vips-${LIBVIPS_VERSION} && \
+	CFLAGS="-g -O3" CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 -g -O3" \
+    ./configure \
+    --disable-debug \
+    --disable-dependency-tracking \
+    --disable-introspection \
+    --disable-static \
+    --enable-gtk-doc-html=no \
+    --enable-gtk-doc=no \
+    --enable-pyvips8=no && \
+  make && \
+  make install && \
+  ldconfig
+
+# Installing golangci-lint
+RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v${GOLANGCILINT_VERSION}
+
+# [Optional] Uncomment the next lines to use go get to install anything else you need
+# USER vscode
+# RUN go get -x <your-dependency-or-tool>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local arm64/Apple Silicon.
+			"VARIANT": "1.17-bullseye",
+			// Options
+			"NODE_VERSION": "none"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [9000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"docker-from-docker": "latest"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,7 @@
 			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "1.17-bullseye",
-			// Options
-			"NODE_VERSION": "none"
+			"VARIANT": "1.17-bullseye"
 		}
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],


### PR DESCRIPTION
This PR adds a Dev Container which can be used to work on the codebase more easily, through VS Code (via the Remote-Containers extension) or GitHub Codespaces.

Because imaginary needs some libraries installed, setting them up–and having the right versions–on a development machine can be a pain. Using a dev container removes the problem and allows working on imaginary quickly and without messing up with the host.

The dev container is based on the official containers for Go 1.17 and it includes the libraries that imaginary needs as per the Dockerfile (both dev and runtime). Note that this used Debian Bullseye as base, so see also #384.