### PR TITLE
Fix typos

### DIFF
--- a/History.md
+++ b/History.md
@@ -392,7 +392,7 @@ v0.1.26 / 2016-09-06
   * feat(docs): update CLI usage and help
   * feat: forward authorization headers support
   * Fix description for URL source, and allowed origins server options (#83)
-  * fix(version): ups, editting from iPad
+  * fix(version): ups, editing from iPad
   * fix(version): unresolved conflict
   * merge: fix History conflicts
   * Merge branch 'develop'
@@ -750,7 +750,7 @@ v0.1.24 / 2016-04-21
 ==================
 
   * feat(#18): http docs
-  * fix(travis): another attemp
+  * fix(travis): another attempt
   * fix(travis)
   * fix(docs)
   * fix(travis)

--- a/error.go
+++ b/error.go
@@ -19,7 +19,7 @@ var (
 	ErrEmptyBody            = NewError("Empty or unreadable image", http.StatusBadRequest)
 	ErrMissingParamFile     = NewError("Missing required param: file", http.StatusBadRequest)
 	ErrInvalidFilePath      = NewError("Invalid file path", http.StatusBadRequest)
-	ErrInvalidImageURL      = NewError("Unvalid image URL", http.StatusBadRequest)
+	ErrInvalidImageURL      = NewError("Invalid image URL", http.StatusBadRequest)
 	ErrMissingImageSource   = NewError("Cannot process the image due to missing or invalid params", http.StatusBadRequest)
 	ErrNotImplemented       = NewError("Not implemented endpoint", http.StatusNotImplemented)
 	ErrInvalidURLSignature  = NewError("Invalid URL signature", http.StatusBadRequest)

--- a/source_http_test.go
+++ b/source_http_test.go
@@ -119,7 +119,7 @@ func TestHttpImageSourceForwardAuthHeader(t *testing.T) {
 		source.setAuthorizationHeader(oreq, r)
 
 		if oreq.Header.Get("Authorization") != "foobar" {
-			t.Fatal("Missmatch Authorization header")
+			t.Fatal("Mismatch Authorization header")
 		}
 	}
 }
@@ -143,7 +143,7 @@ func TestHttpImageSourceForwardHeaders(t *testing.T) {
 		source.setForwardHeaders(oreq, r)
 
 		if oreq.Header.Get(header) != "foobar" {
-			t.Fatal("Missmatch custom header")
+			t.Fatal("Mismatch custom header")
 		}
 	}
 }
@@ -231,7 +231,7 @@ func TestHttpImageSourceEmptyForwardedHeaders(t *testing.T) {
 
 	if len(source.Config.ForwardHeaders) != 0 {
 		t.Log(source.Config.ForwardHeaders)
-		t.Fatal("Setted empty custom header")
+		t.Fatal("Set empty custom header")
 	}
 
 	oreq := newHTTPRequest(source, r, http.MethodGet, testURL)


### PR DESCRIPTION
Found via `codespell -S .git`.