### PR TITLE
Fix operation name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,7 +1093,7 @@ Self-documented JSON operation schema:
 - **zoom** - Same as [`/zoom`](#get--post-zoom) endpoint.
 - **convert** - Same as [`/convert`](#get--post-convert) endpoint.
 - **watermark** - Same as [`/watermark`](#get--post-watermark) endpoint.
-- **watermarkimage** - Same as [`/watermarkimage`](#get--post-watermarkimage) endpoint.
+- **watermarkImage** - Same as [`/watermarkimage`](#get--post-watermarkimage) endpoint.
 - **blur** - Same as [`/blur`](#get--post-blur) endpoint.
 
 ###### Example


### PR DESCRIPTION
At pipeline endpoint, operation for /watermarkimage is "watermarkImage", with an 'i' in uppercase.

I had to look at <https://github.com/h2non/imaginary/blob/b632dae8cc321452c3f85bcae79c580b1ae1ed84/image.go#L31> to learn this.