### PR TITLE
Fix: Removed deprecated argument from Readme.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ docker pull h2non/imaginary
 
 Start the container with optional flags (default listening on port 9000)
 ```
-docker run -p 9000:9000 h2non/imaginary -cors -gzip
+docker run -p 9000:9000 h2non/imaginary -cors
 ```
 
 Start the container enabling remote URL source image processing via GET requests and `url` query param.


### PR DESCRIPTION
https://github.com/h2non/imaginary/blob/8f36a26c448be8c151a3878404b75fcd1cd3cf0c/imaginary.go#L170